### PR TITLE
Typos in cerise exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ top of the usual memory capabilities, and focus on reasoning about the
 We instantiate the Iris program logic to reason about programs running on the
 machine, and we use it to define a logical relation characterizing the behavior
 of unknown code. The logical relation is much simpler than what one would need
-do reason about more complex stack-like properties: in particular, we only need
+to reason about more complex stack-like properties: in particular, we only need
 to rely on standard Iris invariants.
 
 For more information, see this [extended

--- a/proofmode.md
+++ b/proofmode.md
@@ -145,7 +145,7 @@ manual steps. One needs to do:
    by `iInstr`); `wp_end`: when the execution stopped (on fail/halt).
 
 - `changePCto a`: change the current address of pc to `a`. Uses `solve_addr` to
-  prove that the current addres is indeed equal to `a`.
+  prove that the current address is indeed equal to `a`.
 
 
 ## Understanding and debugging the tactics

--- a/theories/exercises/cerise_modularity.v
+++ b/theories/exercises/cerise_modularity.v
@@ -1,9 +1,9 @@
 (** This file is a tutorial to learn how to use the Cerise Program Logic within Coq.
     We will use the modularity of the program logic to use the specification of
-    a macro into a program, and show how the macro can be linked via a linking table.
+    a macro in a program, and show how the macro can be linked via a linking table.
 
     Prerequisites:
-    We assume the user have already followed the first part of the tutorial
+    We assume the user has already followed the first part of the tutorial
     "cerise_tutorial.v" and is able to prove the specification of a program
     with known code using the Cerise Proof Mode. *)
 

--- a/theories/exercises/cerise_modularity.v
+++ b/theories/exercises/cerise_modularity.v
@@ -74,10 +74,10 @@ Section increment_macro.
       is necessary. *)
 
   (** The following is a very simple example of program that uses the macro. The
-        program assumes that R0 contains a writing capability pointing to the
-        memory. It initializes the value of this memory address at 0, calls the
-        increment macro to increment the value, and finally loads the
-        incremented value in the register R1.
+      program assumes that R0 contains a writing capability pointing to the
+      memory. It initializes the value of this memory address at 0, calls the
+      increment macro to increment the value, and finally loads the
+      incremented value in the register R1.
 
       The reader may notice 3 blocks of instructions, separated by the `++`
       operator. The proof will leverage this block separation using new

--- a/theories/exercises/cerise_modularity.v
+++ b/theories/exercises/cerise_modularity.v
@@ -73,17 +73,18 @@ Section increment_macro.
       with larger and complex macros (e.g. involving a loop), this modularity
       is necessary. *)
 
-  (** The following program is a very simple example of program that use
-      the macro. The program assumes that R0 contains a writing capability
-      pointing to the memory. The program initializes the value of this memory
-      address at 0, calls the increment macro to increment the value, and
-      finally load the value of the incremented value in the register R1.
+  (** The following is a very simple example of program that uses the macro. The
+        program assumes that R0 contains a writing capability pointing to the
+        memory. It initializes the value of this memory address at 0, calls the
+        increment macro to increment the value, and finally loads the
+        incremented value in the register R1.
 
       The reader may notice 3 blocks of instructions, separated by the `++`
       operator. The proof will leverage this block separation using new
-      tactics, detailled in `proofmode.md`, section `Focusing a sub-block`.
-      The new tactics allow to focus on a block, prove its specification
-      locally, and then continue the proof of the global program. *)
+      `focus_block` tactics, detailled in `proofmode.md`, section `Focusing a
+      sub-block`. They allow us to focus on a block, prove its specification
+      locally, and then continue the proof of the global program.
+      *)
   Definition prog_instrs: list Word :=
     encodeInstrsW [Store r_t0 0 ] ++
             incr_instrs r_t0 r_t1 ++
@@ -155,14 +156,14 @@ Section rclear_macro.
           `{MP: MachineParameters}.
 
   (** In this section, we will use a pre-defined macro in Cerise, `rclear`.
-      `rclear` is a macro that clears (puts 0) a list of registers given in
+      `rclear` is a macro that clears (puts 0) the list of registers given as
       argument. *)
 
   (** The following program assumes that the register r0 contains a capability
       that points to a buffer with at least 2 integers.
       It performs the addition of the 2 integers of the buffer and stores the
       result at the address of the second integer.
-      Then, the program clears all the used registers (to remove every trace of
+      Then, it clears all the used registers (to remove every trace of
       the computations) and halts the machine. *)
   Definition secret_add_instrs: list Word :=
     encodeInstrsW
@@ -176,8 +177,8 @@ Section rclear_macro.
             encodeInstrsW [Halt].
 
   (** **** Exercise 3 --- Secret addition
-        Define the lemma `secret_add_spec` that specify the program
-        `secret_add_instrs` and prove the specification.
+        Define the lemma `secret_add_spec` that specifies the program
+        `secret_add_instrs` and prove it.
 
         Use the tactics to focus and unfocus the block.
         The specification of the `rclear` macro is `rclear_spec`,
@@ -189,7 +190,7 @@ Section rclear_macro.
         We urge the reader to search lemmas about `big_sepM` and
         `gmap`.
 
-        Hint (proof): usefull lemmas
+        Hint (proof): useful lemmas
         - big_sepM_insert
         - big_sepM_insert_delete
         - delete_insert_ne

--- a/theories/exercises/cerise_modularity_solutions.v
+++ b/theories/exercises/cerise_modularity_solutions.v
@@ -1,9 +1,9 @@
 (** This file is a tutorial to learn how to use the Cerise Program Logic within Coq.
     We will use the modularity of the program logic to use the specification of
-    a macro into a program, and show how the macro can be linked via a linking table.
+    a macro in a program, and show how the macro can be linked via a linking table.
 
     Prerequisites:
-    We assume the user have already followed the first part of the tutorial
+    We assume the user has already followed the first part of the tutorial
     "cerise_tutorial.v" and is able to prove the specification of a program
     with known code using the Cerise Proof Mode. *)
 

--- a/theories/exercises/cerise_modularity_solutions.v
+++ b/theories/exercises/cerise_modularity_solutions.v
@@ -94,10 +94,10 @@ Section increment_macro.
    *)
 
   (** The following is a very simple example of program that uses the macro. The
-        program assumes that R0 contains a writing capability pointing to the
-        memory. It initializes the value of this memory address at 0, calls the
-        increment macro to increment the value, and finally loads the
-        incremented value in the register R1.
+      program assumes that R0 contains a writing capability pointing to the
+      memory. It initializes the value of this memory address at 0, calls the
+      increment macro to increment the value, and finally loads the
+      incremented value in the register R1.
 
       The reader may notice 3 blocks of instructions, separated by the `++`
       operator. The proof will leverage this block separation using new

--- a/theories/exercises/cerise_modularity_solutions.v
+++ b/theories/exercises/cerise_modularity_solutions.v
@@ -93,16 +93,16 @@ Section increment_macro.
       is necessary.
    *)
 
-  (** The following program is a very simple example of program that use
-      the macro. The program assumes that R0 contains a writing capability
-      pointing to the memory. The program initializes the value of this memory
-      address at 0, calls the increment macro to increment the value, and
-      finally load the value of the incremented value in the register R1.
+  (** The following is a very simple example of program that uses the macro. The
+        program assumes that R0 contains a writing capability pointing to the
+        memory. It initializes the value of this memory address at 0, calls the
+        increment macro to increment the value, and finally loads the
+        incremented value in the register R1.
 
       The reader may notice 3 blocks of instructions, separated by the `++`
       operator. The proof will leverage this block separation using new
-      tactics, detailled in `proofmode.md`, section `Focusing a sub-block`.
-      The new tactics allow to focus on a block, prove its specification
+      `focus_block` tactics, detailled in `proofmode.md`, section `Focusing a
+      sub-block`. They allow us to focus on a block, prove its specification
       locally, and then continue the proof of the global program.
    *)
   Definition prog_instrs: list Word :=
@@ -178,14 +178,14 @@ Section rclear_macro.
           `{MP: MachineParameters}.
 
   (** In this section, we will use a pre-defined macro in Cerise, `rclear`.
-      `rclear` is a macro that clears (puts 0) a list of registers given in
+      `rclear` is a macro that clears (puts 0) the list of registers given as
       argument. *)
 
   (** The following program assumes that the register r0 contains a capability
       that points to a buffer with at least 2 integers.
       It performs the addition of the 2 integers of the buffer and stores the
       result at the address of the second integer.
-      Then, the program clears all the used registers (to remove every trace of
+      Then, it clears all the used registers (to remove every trace of
       the computations) and halts the machine. *)
   Definition secret_add_instrs: list Word :=
     encodeInstrsW
@@ -199,8 +199,8 @@ Section rclear_macro.
             encodeInstrsW [Halt].
 
   (** **** Exercise 3 --- Secret addition
-        Define the lemma `secret_add_spec` that specify the program
-        `secret_add_instrs` and prove the specification.
+        Define the lemma `secret_add_spec` that specifies the program
+        `secret_add_instrs` and prove it.
 
         Use the tactics to focus and unfocus the block.
         The specification of the `rclear` macro is `rclear_spec`,
@@ -212,7 +212,7 @@ Section rclear_macro.
         We urge the reader to search lemmas about `big_sepM` and
         `gmap`.
 
-        Hint (proof): usefull lemmas
+        Hint (proof): useful lemmas
         - big_sepM_insert
         - big_sepM_insert_delete
         - delete_insert_ne

--- a/theories/exercises/cerise_tutorial.v
+++ b/theories/exercises/cerise_tutorial.v
@@ -206,8 +206,7 @@ Section base_program.
   (** The tactic `iGo "Hprog"` steps through multiple instructions,
      until a side-condition needs to be prove manually. *)
 
-  (** ========== Exercise 1 --- More automation with iGo ============
-
+  (** **** Exercise 1 --- More automation with iGo
       Prove the specification of the previous example using the automated
       tactic `iGo`. In order to leverage the strengh of the tactic, the memory
       resources should be ready before the execution of the tactic, in

--- a/theories/exercises/cerise_tutorial.v
+++ b/theories/exercises/cerise_tutorial.v
@@ -206,19 +206,20 @@ Section base_program.
   (** The tactic `iGo "Hprog"` steps through multiple instructions,
      until a side-condition needs to be prove manually. *)
 
-  (** **** Exercise 1 --- More automation with iGo
+  (** ========== Exercise 1 --- More automation with iGo ============
+
       Prove the specification of the previous example using the automated
-      tactic iGo. In order to leverage the strengh of the tactic, the memory
+      tactic `iGo`. In order to leverage the strengh of the tactic, the memory
       resources should be ready before the execution of the tactic, in
       particular, the memory buffer should be split at the beginning of the
       proof: it will allows the tactic `iGo` to step through multiple
       instructions at once.
 
       Tips: take inspiration on the proof of the previous exercise, but we
-            recommend to try to manipulate the SL resources and the addresses
+            recommend to try to manipulate the SL resources and the address
             arithmetic by yourself.
-            Indeed, adresses arithmetic is a very common side-condition,
-            and the lemmas often requires you to manipulate the PL resources
+            Indeed, address arithmetic is a very common side-condition,
+            and the lemmas often require you to manipulate the PL resources
             in order to make them fit with the hypothesis. *)
 
   Lemma prog_spec_igo
@@ -251,7 +252,7 @@ Section base_program.
     iIntros "(HPC& Hprog& Hr1& Hmem& Hr2& Hcont)".
     subst e_mem e_prog; simpl.
 
-    (* Derives the facts from the codefrag *)
+    (* Derive the facts from the codefrag *)
     (* FILL IN HERE *)
 
     (* Prepare the memory resource for the Store *)

--- a/theories/exercises/cerise_tutorial.v
+++ b/theories/exercises/cerise_tutorial.v
@@ -101,17 +101,17 @@ Section base_program.
 
       Because we work with addresses, which are actually finite integers,
       we need to assume the addresses are always valid when we do addresses
-      arithmetic operations ( for instance, there is no overflow of the memory).
+      arithmetic operations (for instance, there is no overflow of the memory).
       In particular, the memory buffer is a contiguous region of memory where
       all the addresses are in the bounds of the memory.
 
       For simplicity, we assume the buffer is filled with 0.
 
-      When the whole program is a list of instruction, it is required to
+      When the whole program is a list of instructions, it is required to
       manually get some helping facts before reasoning on the instructions,
       using the tactic `codefrag_facts "Hprog"`. This tactic has to be used
       when the `codefrag` assertion is used. It allows to get some additionnal
-      fact about the memory addresses containing the code. It is a boilerplate.
+      facts about the memory addresses containing the code. It is a boilerplate.
 
       To prove the specification, the idea is to manipulate the resources, such
       that we have all the required assertion that fit with the corresponding

--- a/theories/exercises/cerise_tutorial.v
+++ b/theories/exercises/cerise_tutorial.v
@@ -172,8 +172,8 @@ Section base_program.
 
     (* Store requires the resource (b_mem ^+ 1), we need to
        destruct the region_mapsto.
-       This essentially the same as destructing a list into (first element)::(rest of list)
-       We do it twice since we need the second element (b_mem ^+ 1) *)
+       This essentially the same as destructing a list into (first element)::(rest of list).
+       We do it twice since we need the second element (b_mem ^+ 1). *)
     iDestruct (region_mapsto_cons with "Hmem") as "(Hmem0& Hmem1)".
     { transitivity (Some (b_mem ^+1)%a) ; auto ; by solve_addr.  }
     { by solve_addr. }

--- a/theories/exercises/cerise_tutorial.v
+++ b/theories/exercises/cerise_tutorial.v
@@ -273,7 +273,7 @@ Section base_program.
       However, in order to get a better understanding of the way to use the
       WP rules in Cerise, we propose to prove the previous lemma using the
       fully detailed tactics.
-      It is also useful if the assertion that embed the code is not the
+      It is also useful if the assertion that embeds the code is not the
       `codefrag` predicate, but for instance, the big conjonction separation
       `[∗ list]` --- even though it is usually possible to rewrite the one
       in term of the other. *)
@@ -284,6 +284,8 @@ Section base_program.
         We explain the different steps for the first instruction `Lea`.
         Complete the proof.
    *)
+
+  From cap_machine Require Import contiguous.
 
   Lemma prog_spec_detailed
     p_pc b_pc e_pc (* pc *)
@@ -315,7 +317,7 @@ Section base_program.
     intros * Hpc_perm Hpc_bounds Hprog_addr Hmem_bounds.
     iIntros "(HPC& Hprog& Hr1& Hmem& Hr2& Hcont)".
     subst e_mem e_prog; simpl in *.
-    (* In order to use the tactic `iCorrectPC` that solve the side-condition
+    (* In order to use the tactic `iCorrectPC` that solves the side-condition
        about the PC, we need this assertion, equivalent to
        `Hpc_perm /\ Hpc_bounds` *)
     assert (Hpc_correct : isCorrectPC_range p_pc b_pc e_pc a_prog (a_prog ^+ 2)%a).
@@ -339,7 +341,7 @@ Section base_program.
     iApply (wp_lea_success_z with "[$HPC $Hi $Hr1]").
     { apply decode_encode_instrW_inv. }
     { iCorrectPC a_prog (a_prog ^+ 2)%a. }
-    { iContiguous_next Hprog_addr 0. }
+    { iContiguous_next Hprog_addr 0%nat. }
     { transitivity (Some (b_mem ^+ 1 )%a) ; auto ; solve_addr. }
     { auto. }
     (* Introduce the postconditions of the rule and re-focus the expression. *)

--- a/theories/exercises/cerise_tutorial_solutions.v
+++ b/theories/exercises/cerise_tutorial_solutions.v
@@ -5,7 +5,7 @@
  *)
 
 From iris.proofmode Require Import tactics.
-From cap_machine Require Import rules proofmode macros_helpers.
+From cap_machine Require Import rules proofmode macros_helpers contiguous.
 Open Scope Z_scope.
 
 Section base_program.
@@ -17,20 +17,7 @@ Section base_program.
       Lea r_t1 1 ;
       Store r_t1 r_t2 ].
 
-  (** **** Exercise 1 - More automation with iGo
-      Prove the specification of the previous example using the automated
-      tactic iGo. In order to leverage the strengh of the tactic, the memory
-      resources should be ready before the execution of the tactic, in
-      particular, the memory buffer should be splitted at the beginning of the
-      proof: it will allows the tactic `iGo` to step through multiple
-      instructions at once.
-
-      Tips: take inspiration on the proof of the previous exercise, but I
-            recommend to try to manipulate the SL resources and the adresses
-            arithmetic by yourself.
-            Indeed, adresses arithmetic is a very common side-condition,
-            and the lemmas often requires you to manipulate the resources
-            in order to make them fit with the hypethesis. *)
+  (** **** Exercise 1 - More automation with iGo *)
 
   Lemma prog_spec_igo
     p_pc b_pc e_pc a_prog (* pc *)
@@ -95,13 +82,7 @@ Section base_program.
     done.
   Qed.
 
-  (** **** Exercise 2 --- Manual detailled proofs
-        For this exercise, we propose to re-do the proof of the previous
-        specification, using the manual WP rules.
-        We explain the different steps for the first instruction `Lea`.
-        Complete the proof, for the instruction `Store` and the
-        postcondition.
-   *)
+  (** **** Exercise 2 --- Manual detailled proofs *)
 
   Lemma prog_spec_detailed
     p_pc b_pc e_pc (* pc *)
@@ -156,7 +137,7 @@ Section base_program.
     iApply (wp_lea_success_z with "[$HPC $Hi $Hr1]").
     { apply decode_encode_instrW_inv. }
     { iCorrectPC a_prog (a_prog ^+ 2)%a. }
-    { iContiguous_next Hprog_addr 0. }
+    { iContiguous_next Hprog_addr 0%nat. }
     { transitivity (Some (b_mem ^+ 1 )%a) ; auto ; solve_addr. }
     { auto. }
     (* Introduce the postconditions of the rule and re-focus the expression. *)


### PR DESCRIPTION
Some typo fixes and additional comments for the cerise tutorial.
Plus added a missing import.