### PR TITLE
Coq 8.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- LTeX: language=en -->
+
 This repository contains the Coq mechanization of a capability machine and
 principles to reason about the interaction of known and unknown code.
 
@@ -14,7 +16,7 @@ top of the usual memory capabilities, and focus on reasoning about the
 We instantiate the Iris program logic to reason about programs running on the
 machine, and we use it to define a logical relation characterizing the behavior
 of unknown code. The logical relation is much simpler than what one would need
-do reason about more complex stack-like properties: in particular, we only need
+to reason about more complex stack-like properties: in particular, we only need
 to rely on standard Iris invariants.
 
 For more information, see this [extended
@@ -31,7 +33,7 @@ The simplest option is to create a fresh *local* opam switch with everything
 needed, by running the following commands:
 
 ```
-opam switch create -y --repositories=default,coq-released=https://coq.inria.fr/opam/released,iris-dev=git+https://gitlab.mpi-sws.org/iris/opam.git . ocaml-base-compiler.4.11.2
+opam switch create -y --repositories=default,coq-released=https://coq.inria.fr/opam/released,iris-dev=git+https://gitlab.mpi-sws.org/iris/opam.git . ocaml-base-compiler.4.14.0
 eval $(opam env)
 ```
 

--- a/opam
+++ b/opam
@@ -4,7 +4,7 @@ opam-version: "2.0"
 maintainer: ""
 authors: [ "anonymous" ]
 depends: [
-  "coq" {= "8.15.0"}
+  "coq" {= "8.16.1"}
   "coq-iris" {= "4.0.0"}
   "coq-stdpp" {= "1.8.0"}
   "coq-equations"

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -583,4 +583,3 @@ Proof.
   generalize (normal_always_step σ); intros (?&?&?).
   eapply head_reducible_from_step. eauto.
 Qed.
-

--- a/theories/examples/interval_client_adequacy.v
+++ b/theories/examples/interval_client_adequacy.v
@@ -641,7 +641,8 @@ Section int_client_adequacy.
       1,2: apply le_addr_withinBounds'. all: try solve_addr.
       apply seal_table_size. }
     { eauto. }
-    { rewrite /offset_to_checki. pose proof interval_client_closure_size.
+    { rewrite /offset_to_checki.
+       pose proof interval_client_closure_size. rewrite /offset_to_checki.
       rewrite /interval_client_closure_move_offset in HH.
       rewrite /interval_client_closure_move_offset /interval_client_closure_instrs_length.
       simpl in *. solve_addr. }

--- a/theories/examples/macros.v
+++ b/theories/examples/macros.v
@@ -960,7 +960,7 @@ Section macros.
     iAssert (⌜((length a) =? (length (mclear_instrs r)) = true)%nat⌝)%I as %Hlen.
     { destruct (((length a) =? (length (mclear_instrs r)))%nat) eqn:Hlen; auto.
       rewrite /mclear Hlen. by iApply bi.False_elim. }
-    rewrite /mclear Hlen /mclear_instrs; simpl in Hlen. apply beq_nat_true in Hlen.
+    rewrite /mclear Hlen /mclear_instrs; simpl in Hlen. apply Nat.eqb_eq in Hlen.
     destruct a as [| a1 a]; inversion Hlen; simpl.
     move: (contiguous_between_cons_inv_first _ _ _ _ Hnext).
     match goal with |- (?a = _) -> _ => intro; subst a end.
@@ -1032,7 +1032,7 @@ Section macros.
     { have: (isCorrectPC (WCap p b e a_first)).
       { apply Hvpc. eapply contiguous_between_middle_bounds'; eauto. constructor. }
       inversion 1; subst.
-      destruct H14 as [? | ? ]; subst; auto. }
+      destruct H15 as [? | ? ]; subst; auto. }
     iApply (wp_lea_success_z _ _ _ _ a7 a8 _ r_t2 p _ _ a6 10 a_end with "[HPC Hi Hr_t2]");
       first apply decode_encode_instrW_inv; first iCorrectPC a_first a'; auto.
     { iContiguous_next Hnext 8. }

--- a/theories/examples/mkregion_helpers.v
+++ b/theories/examples/mkregion_helpers.v
@@ -18,7 +18,8 @@ Proof.
   { intros * Hl. cbn.
     rewrite (_: b = e). 2: solve_addr.
     rewrite finz_seq_between_empty //. 2: solve_addr. cbn.
-    split. by inversion 1. intros [? [? ?] ]. congruence. }
+    split. by inversion 1. intros [? [? ?] ].
+    rewrite lookup_nil in H0. discriminate H0. }
   { intros * Hl. cbn in *.
     rewrite finz_seq_between_cons. 2: solve_addr. cbn.
     split.

--- a/theories/exercises/subseg_buffer_call.v
+++ b/theories/exercises/subseg_buffer_call.v
@@ -6,12 +6,12 @@ From cap_machine Require Import fundamental logrel macros_helpers rules proofmod
 From cap_machine.examples Require Import template_adequacy.
 From cap_machine.exercises Require Import register_tactics subseg_buffer.
 From cap_machine.examples Require Import template_adequacy template_adequacy_ocpl.
+From cap_machine Require Import call callback.
 Open Scope Z_scope.
 
 (** Variant of the exercise where we use the call macro
     to jump to the adversary *)
 Section program_call.
-  From cap_machine Require Import call callback.
 
   Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
           `{MP: MachineParameters}.
@@ -294,7 +294,7 @@ Section program_call.
        -∗ WP Seq (Instr Executable) {{λ v,
                (⌜v = HaltedV⌝ → ∃ r : Reg, full_map r ∧ registers_mapsto r ∗ na_own logrel_nais ⊤)%I
                ∨ ⌜v = FailedV⌝ }})%I.
-  
+
   Proof with (try solve_addr').
     iIntros
       (Hpc_perm Hpc_bounds Hcont Hwb_malloc Hwb_assert Hlink_malloc Hlink_assert Hsize Hdom)
@@ -489,7 +489,7 @@ Section program_call.
       replace (a_prog ^+ 11%nat)%a with a_call. done.
       rewrite Hlength_progi in Ha_call... }
     do 4 (rewrite delete_insert_ne ; eauto).
-    
+
     (* 2 - extract r2 and r3 *)
     extract_register r_t2 with "Hrmap" as ( w2 Hw2 ) "[Hr2 Hrmap]".
     rewrite delete_insert_ne ; auto.

--- a/theories/logrel.v
+++ b/theories/logrel.v
@@ -287,7 +287,7 @@ Section logrel.
            + do 2 f_equal. apply eq_proofs_unicity. decide equality.
            + exfalso. by apply (Nat.leb_le n RegNum) in fin.
          - intros x.
-           + destruct x;[lia|]. apply leb_le in fin. lia.
+           + destruct x;[lia|]. apply Nat.leb_le in fin. lia.
          - intros i Hlt. unfold n_to_regname.
            destruct (Nat.le_dec i RegNum);auto.
            lia.

--- a/theories/region.v
+++ b/theories/region.v
@@ -53,7 +53,7 @@ Section region.
       iDestruct (big_sepL2_length with "A") as %Hlen.
       rewrite (finz_seq_between_decomposition b a e) //.
       assert (Hlnws: n = length (take n ws)).
-      { rewrite take_length. rewrite Min.min_l; auto.
+      { rewrite take_length. rewrite Nat.min_l; auto.
         rewrite <- Hlen. subst n. rewrite !finz_seq_between_length /finz.dist.
         solve_addr. }
       generalize (take_drop n ws). intros HWS.
@@ -118,7 +118,7 @@ Section region.
     iDestruct (big_sepL2_length with "Hreg") as %Hlen.
     rewrite (finz_seq_between_decomposition b a e) //.
     assert (Hlnws: n = length (take n ws)).
-    { rewrite take_length. rewrite Min.min_l; auto.
+    { rewrite take_length. rewrite Nat.min_l; auto.
       rewrite <- Hlen. subst n. rewrite !finz_seq_between_length /finz.dist.
       solve_addr. }
     generalize (take_drop n ws). intros HWS.
@@ -222,7 +222,7 @@ Section region.
       iDestruct (big_sepL2_length with "A") as %Hlen.
       rewrite (finz_seq_between_decomposition b a e) //.
       assert (Hlnws: n = length (take n ws)).
-      { rewrite take_length. rewrite Min.min_l; auto.
+      { rewrite take_length. rewrite Nat.min_l; auto.
         rewrite <- Hlen. subst n. rewrite !finz_seq_between_length /finz.dist.
         solve_addr. }
       generalize (take_drop n ws). intros HWS.
@@ -320,7 +320,7 @@ Section region.
        rewrite (_: finz.dist b e - finz.dist b a = finz.dist a e)...
    Qed.
 
-   
+
 End region.
 
 Global Notation "[[ b , e ]] ↦ₐ [[ ws ]]" := (region_mapsto b e ws)

--- a/theories/stdpp_extra.v
+++ b/theories/stdpp_extra.v
@@ -514,13 +514,13 @@ Proof.
     simpl.
     assert (a ∈ [a]); first apply elem_of_list_here.
     destruct (decide_rel elem_of a [a]); last contradiction.
-    rewrite -minus_n_O.
+    rewrite Nat.sub_0_r.
     apply list_difference_length_ni; auto.
   - simpl.
     assert (¬ (a ∈ [b])).
     { rewrite /not. intros Hin. apply elem_of_list_singleton in Hin. congruence. }
     destruct (decide_rel elem_of a [b]); first contradiction.
-    rewrite -minus_n_O /=.
+    rewrite Nat.sub_0_r /=.
     inversion Hndup; subst.
     apply elem_of_cons in Ha.
     destruct Ha as [Hcontr | Ha]; first congruence.


### PR DESCRIPTION
Fix some warnings and all errors when using latest Coq version.

This compiled fine with : 
- ocaml-base-compiler 4.14.0
- coq 8.16.1
- coq-stdpp 1.8.0
- coq-iris 4.0.0

The only warnings are in `cap_lang`, and they seem safe to ignore:

```
File "theories/cap_lang.v", line 523, characters 0-93
523 | Canonical Structure cap_ectx_lang `{MachineParameters} := EctxLanguageOfEctxi cap_ectxi_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to ectxi_lang_ectx_mixin by
 | ectx_language_mixin in @cap_ectx_lang: redundant with ectxi_lang_ectx

File "theories/cap_lang.v", line 523, characters 0-93
523 | Canonical Structure cap_ectx_lang `{MachineParameters} := EctxLanguageOfEctxi cap_ectxi_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to head_step by
 | ectx_language.head_step in @cap_ectx_lang: redundant with ectxi_lang_ectx

File "theories/cap_lang.v", line 523, characters 0-93
523 | Canonical Structure cap_ectx_lang `{MachineParameters} := EctxLanguageOfEctxi cap_ectxi_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to fill by ectx_language.fill in
 | @cap_ectx_lang: redundant with ectxi_lang_ectx

File "theories/cap_lang.v", line 523, characters 0-93
523 | Canonical Structure cap_ectx_lang `{MachineParameters} := EctxLanguageOfEctxi cap_ectxi_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to flip by comp_ectx in
 | @cap_ectx_lang: redundant with ectxi_lang_ectx

File "theories/cap_lang.v", line 523, characters 0-93
523 | Canonical Structure cap_ectx_lang `{MachineParameters} := EctxLanguageOfEctxi cap_ectxi_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to nil by empty_ectx in
 | @cap_ectx_lang: redundant with ectxi_lang_ectx

File "theories/cap_lang.v", line 523, characters 0-93
523 | Canonical Structure cap_ectx_lang `{MachineParameters} := EctxLanguageOfEctxi cap_ectxi_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to list by ectx in @cap_ectx_lang:
 | redundant with ectxi_lang_ectx [redundant-canonical-projection,typechecker]

File "theories/cap_lang.v", line 524, characters 0-82
524 | Canonical Structure cap_lang `{MachineParameters} := LanguageOfEctx cap_ectx_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to ectx_lang_mixin by language_mixin
 | in @cap_lang: redundant with ectx_lang

File "theories/cap_lang.v", line 524, characters 0-82
524 | Canonical Structure cap_lang `{MachineParameters} := LanguageOfEctx cap_ectx_lang.
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning:
 | Ignoring canonical projection to ectx_language.prim_step by
 | language.prim_step in @cap_lang: redundant with ectx_lang
```