### PR TITLE
Simplify `stdpp_extra`

### DIFF
--- a/theories/addr_reg.v
+++ b/theories/addr_reg.v
@@ -204,7 +204,7 @@ Lemma regmap_full_dom {A} (r: gmap RegName A):
 Proof.
   intros Hfull. apply (anti_symm subseteq); rewrite elem_of_subseteq.
   - intros rr _. apply all_registers_s_correct.
-  - intros rr _. rewrite -elem_of_gmap_dom. apply Hfull.
+  - intros rr _. rewrite elem_of_dom. apply Hfull.
 Qed.
 
 (* -------------------------------- Memory addresses -----------------------------------*)

--- a/theories/attic/dynamic_sealing.v
+++ b/theories/attic/dynamic_sealing.v
@@ -261,7 +261,7 @@ Section sealing.
 
     codefrag_facts "Hprog".
     focus_block_0 "Hprog" as "Hprog" "Hcont".
-    assert (is_Some (rmap !! r_t7)) as [w7 Hw7];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t7)) as [w7 Hw7];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t7 with "Hregs") as "[Hr_t7 Hregs]";[apply Hw7|].
     iGo "Hprog".
     unfocus_block "Hprog" "Hcont" as "Hprog".
@@ -364,7 +364,7 @@ Section sealing.
     iIntros (Hvpc Hcont Hdom Hbounds Hf_m Hnclose') "(HPC & Hr_t0 & Hregs & Hown & Hprog & #Hmalloc & Hpc_b & Ha_r' & Hφ)".
 
     focus_block 2 "Hprog" as a_middle Ha_middle "Hprog" "Hcont".
-    assert (is_Some (rmap !! r_t8)) as [w8 Hw8];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t8)) as [w8 Hw8];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[apply Hw8|].
     iGo "Hprog".
     { rewrite /seal_instrs_length. instantiate (1 := (a_first ^+ length (unseal_instrs))%a).
@@ -387,7 +387,7 @@ Section sealing.
     focus_block 4 "Hprog" as a_middle2 Ha_middle2 "Hprog" "Hcont".
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[simplify_map_eq; auto|].
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]";[simplify_map_eq; auto|].
-    assert (is_Some (rmap !! r_t9)) as [w9 Hw9];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t9)) as [w9 Hw9];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t9 Hregs]";[simplify_map_eq; auto|].
     map_simpl "Hregs".
     iGo "Hprog".
@@ -410,7 +410,7 @@ Section sealing.
     focus_block 6 "Hprog" as a_middle4 Ha_middle4 "Hprog" "Hcont".
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[simplify_map_eq; auto|].
     iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t9 Hregs]";[simplify_map_eq; auto|].
-    assert (is_Some (rmap !! r_t10)) as [w10 Hw10];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t10)) as [w10 Hw10];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t10 with "Hregs") as "[Hr_t10 Hregs]";[simplify_map_eq; auto|].
     map_simpl "Hregs".
     iGo "Hprog". instantiate (1 := a_first). rewrite /unseal_instrs_length. solve_addr.

--- a/theories/attic/list_new.v
+++ b/theories/attic/list_new.v
@@ -670,7 +670,7 @@ Section list.
     iDestruct "HisList" as (hd) "[Hll HisList]". iDestruct "HisList" as (pbvals') "(>HisList & >Hexact & HΦ)".
     iDestruct (big_sepL2_length with "Hprog") as %Hprog_length.
     (* extract some registers *)
-    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t6 with "Hregs") as "[Hr_t6 Hregs]";[apply Hw6|].
 
     focus_block_0 "Hprog" as "Hprog" "Hcont".
@@ -680,9 +680,9 @@ Section list.
     focus_block 1 "Hprog" as a_middle Ha_middle "Hprog" "Hcont".
     iDestruct (big_sepM_insert _ _ r_t6 with "[$Hregs $Hr_t6]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     iDestruct (big_sepM_insert _ _ r_env with "[$Hregs $Hr_env]") as "Hregs".
-    { rewrite !lookup_insert_ne//. rewrite elem_of_gmap_dom_none Hdom. set_solver. }
+    { rewrite !lookup_insert_ne//. rewrite -not_elem_of_dom Hdom. set_solver. }
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hregs $Hr_t1]") as "Hregs".
-    { rewrite !lookup_insert_ne//. rewrite elem_of_gmap_dom_none Hdom. set_solver. }
+    { rewrite !lookup_insert_ne//. rewrite -not_elem_of_dom Hdom. set_solver. }
     iApply malloc_spec; iFrameAutoSolve. 4: iFrame "∗ #". rewrite !dom_insert_L Hdom. clear. set_solver by lia.
     solve_ndisj. lia.
     iNext. iIntros "(HPC & Hmalloc_prog & Hpc_b & Ha_r' & Hreg & Hr_t0 & Hown & Hregs)".
@@ -698,7 +698,7 @@ Section list.
     destruct l;[inversion Hlen_eq|]. apply contiguous_between_cons_inv_first in H1 as Heq. subst f.
     destruct l;[inversion Hlen_eq|]. destruct l;[|inversion Hlen_eq].
     iDestruct "Hbe'" as "[Hbnew [Ha _] ]".
-    rewrite delete_insert. 2: rewrite !lookup_insert_ne// elem_of_gmap_dom_none Hdom;set_solver.
+    rewrite delete_insert. 2: rewrite !lookup_insert_ne// -not_elem_of_dom Hdom;set_solver.
     repeat (rewrite -(insert_commute _ r_env)//).
     iDestruct (big_sepM_delete _ _ r_env with "Hregs") as "[Hr_env Hregs]";[apply lookup_insert|].
     rewrite !(insert_commute _ _ r_t6)// !(delete_insert_ne _ _ r_t6)//.

--- a/theories/examples/adder.v
+++ b/theories/examples/adder.v
@@ -433,16 +433,16 @@ Section adder.
     (* Step 4: use the fact that the continuation is in the expression relation *)
     (* put the registers back in the map *)
     iDestruct (big_sepM_insert with "[$Hregs $Hr3]") as "Hregs".
-    { apply elem_of_gmap_dom_none. set_solver+ Hrmap_dom. }
+    { apply not_elem_of_dom. set_solver+ Hrmap_dom. }
     { rewrite /interp /= !fixpoint_interp1_eq //. }
     iDestruct (big_sepM_insert with "[$Hregs $Hr2]") as "Hregs".
-    { rewrite lookup_insert_ne //. apply elem_of_gmap_dom_none. set_solver+ Hrmap_dom. }
+    { rewrite lookup_insert_ne //. apply not_elem_of_dom. set_solver+ Hrmap_dom. }
     { rewrite /interp /= !fixpoint_interp1_eq //. }
     iDestruct (big_sepM_insert with "[$Hregs $Hr1 Hclosure]") as "Hregs".
-    { rewrite !lookup_insert_ne //. apply elem_of_gmap_dom_none. set_solver+ Hrmap_dom. }
+    { rewrite !lookup_insert_ne //. apply not_elem_of_dom. set_solver+ Hrmap_dom. }
     { eauto. }
     iDestruct (big_sepM_insert with "[$Hregs $Hr0]") as "Hregs".
-    { rewrite !lookup_insert_ne //. apply elem_of_gmap_dom_none. set_solver+ Hrmap_dom. }
+    { rewrite !lookup_insert_ne //. apply not_elem_of_dom. set_solver+ Hrmap_dom. }
     { eauto. }
 
     iApply "Hcont_g"; cycle 1. by iFrame.

--- a/theories/examples/adder_adequacy.v
+++ b/theories/examples/adder_adequacy.v
@@ -186,7 +186,7 @@ Section Adequacy.
     iAssert ([∗ map] r↦w ∈ rmap, (r ↦ᵣ w ∗ interp w))%I with "[Hreg]" as "Hreg".
     { iApply (big_sepM_mono with "Hreg"). intros r w Hr. cbn.
       iIntros "?". iFrame. rewrite fixpoint_interp1_eq.
-      assert (HH: r ∈ dom rmap). by apply elem_of_gmap_dom; eauto.
+      assert (HH: r ∈ dom rmap). by apply elem_of_dom; eauto.
       rewrite /rmap !dom_delete_L in HH.
       destruct (Hrothers r) as [w' [? Hncap] ]. { subst rmap. set_solver+ HH. }
       subst rmap. repeat (rewrite lookup_delete_ne in Hr; [|set_solver+ HH]).

--- a/theories/examples/buffer.v
+++ b/theories/examples/buffer.v
@@ -173,7 +173,7 @@ Proof.
     iFrame. }
 
   assert (is_Some (rmap !! r_t1)) as [w1 Hr1].
-  { rewrite elem_of_gmap_dom Hrmap_dom. set_solver+. }
+  { rewrite -elem_of_dom Hrmap_dom. set_solver+. }
   iDestruct (big_sepM_delete _ _ r_t1 with "Hrmap") as "[[Hr1 _] Hrmap]"; eauto.
 
   iApply (buffer_full_run_spec with "[$Hadv HPC $Hr0 $Hr1 $Hcode $Hrmap $Hna $Hdata]"); auto.

--- a/theories/examples/call.v
+++ b/theories/examples/call.v
@@ -327,14 +327,14 @@ Section call.
       iDestruct (big_sepM_delete _ _ i with "Hlocals") as "[Hi2 Hlocals]";[eauto|].
       iDestruct (regname_dupl_false with "Hi1 Hi2") as "Hfalse". done. }
     iAssert (⌜PC ∉ dom mparams ∧ r_t0 ∉ dom mparams ∧ r1 ∉ dom mparams⌝)%I as %Hdisj4.
-    { repeat iSplit; iIntros (Hcontr); apply elem_of_gmap_dom in Hcontr as [? Hi];
+    { repeat iSplit; iIntros (Hcontr); apply elem_of_dom in Hcontr as [? Hi];
         (iDestruct (big_sepM_delete with "Hparams") as "[Hi1 Hparams]";[by eauto|]).
       by iDestruct (regname_dupl_false with "Hi1 HPC") as "Hfalse".
       by iDestruct (regname_dupl_false with "Hi1 Hr_t0") as "Hfalse".
       by iDestruct (regname_dupl_false with "Hi1 Hr1") as "Hfalse".
     }
     iAssert (⌜PC ∉ dom mlocals ∧ r_t0 ∉ dom mlocals ∧ r1 ∉ dom mlocals⌝)%I as %Hdisj5.
-    { repeat iSplit; iIntros (Hcontr); apply elem_of_gmap_dom in Hcontr as [? Hi];
+    { repeat iSplit; iIntros (Hcontr); apply elem_of_dom in Hcontr as [? Hi];
         (iDestruct (big_sepM_delete with "Hlocals") as "[Hi1 Hlocals]";[by eauto|]).
       by iDestruct (regname_dupl_false with "Hi1 HPC") as "Hfalse".
       by iDestruct (regname_dupl_false with "Hi1 Hr_t0") as "Hfalse".
@@ -342,7 +342,7 @@ Section call.
     }
     iAssert (⌜∀ r, r ∈ {[r_t1; r_t2; r_t3; r_t4; r_t5; r_t6]} → r ≠ r1⌝)%I as %Hneregs.
     { iIntros (r Hin Hcontr). subst. apply Hsub in Hin.
-      apply elem_of_gmap_dom in Hin as [x Hx].
+      apply elem_of_dom in Hin as [x Hx].
       iDestruct (big_sepM_delete with "Hgen") as "[Hr Hgen]";[apply Hx|].
       by iDestruct (regname_dupl_false with "Hr Hr1") as "Hfalse".
     }
@@ -428,7 +428,7 @@ Section call.
     apply contiguous_between_cons_inv_first in Hcont4 as Heq; subst f.
 
     (* get some general purpose registers *)
-    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[apply elem_of_gmap_dom;apply Hsub;repeat constructor|].
+    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[apply elem_of_dom;apply Hsub;repeat constructor|].
     iDestruct (big_sepM_delete _ _ r_t6 with "Hgen") as "[Hr_t6 Hgen]".
     { assert (r_t6 ≠ r1) as Hne;[apply Hneregs;repeat constructor|].
       rewrite !lookup_insert_ne;auto. rewrite lookup_delete_ne;auto. eauto. }
@@ -632,11 +632,11 @@ Section call.
         all: try apply not_elem_of_nil. by apply NoDup_nil. }
       assert (∀ x : RegName, x ∈ [PC; r_t0; r1] → x ∉ (map_to_list mparams).*1) as Hforall.
       { intros x Hin. intros Hcontr%map_to_list_fst. destruct Hdisj4 as [HPC [Hr_t0 Hr1] ].
-        apply elem_of_cons in Hin as [-> | Hin]. apply HPC. apply elem_of_gmap_dom.
+        apply elem_of_cons in Hin as [-> | Hin]. apply HPC. apply elem_of_dom.
         destruct Hcontr as [? Hcontr]. apply elem_of_map_to_list in Hcontr. eauto.
-        apply elem_of_cons in Hin as [-> | Hin]. apply Hr_t0. apply elem_of_gmap_dom.
+        apply elem_of_cons in Hin as [-> | Hin]. apply Hr_t0. apply elem_of_dom.
         destruct Hcontr as [? Hcontr]. apply elem_of_map_to_list in Hcontr. eauto.
-        apply elem_of_cons in Hin as [-> | Hin]. apply Hr1. apply elem_of_gmap_dom.
+        apply elem_of_cons in Hin as [-> | Hin]. apply Hr1. apply elem_of_dom.
         destruct Hcontr as [? Hcontr]. apply elem_of_map_to_list in Hcontr. eauto. inversion Hin.  }
       assert (NoDup ([PC; r_t0; r1] ++ (map_to_list mparams).*1)) as Hdup3.
       { apply NoDup_app. split;[auto|].
@@ -748,7 +748,7 @@ Section call.
       - repeat (apply not_elem_of_cons;split;[auto|]);[|apply not_elem_of_nil]. apply Hneregs. constructor.
       - intros Hcontr%map_to_list_fst. destruct Hcontr as [x Hx].
         apply elem_of_map_to_list in Hx. apply map_disjoint_Some_r with (m1:=rmap) in Hx;auto.
-        apply elem_of_gmap_dom_none in Hx. apply Hx. apply Hsub. constructor.
+        apply not_elem_of_dom in Hx. apply Hx. apply Hsub. constructor.
     }
     apply contiguous_between_cons_inv_first in Hcont7 as Heq. subst f24.
 

--- a/theories/examples/counter.v
+++ b/theories/examples/counter.v
@@ -149,9 +149,9 @@ Section counter.
 
     (* reassemble registers *)
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hregs $Hr_t1]") as "Hregs".
-    { apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+    { apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_env with "[$Hregs $Hr_env]") as "Hregs".
-    { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+    { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
 
     (* jump to unknown code *)
     iDestruct (jmp_to_unknown with "Hcallback") as "Hcallback_now".
@@ -159,7 +159,7 @@ Section counter.
     iMod ("Hcls" with "[Hprog_done Hi $Hown]") as "Hown".
     { iNext. iFrame. iDestruct "Hprog_done" as "($&$&$&$&$)". done. }
     iDestruct (big_sepM_insert _ _ r_t0 with "[$Hregs $Hr_t0]") as "Hregs".
-    { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom. set_solver+. }
+    { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom. set_solver+. }
     iApply (wp_wand with "[-Hφ]").
     { iApply "Hcallback_now"; cycle 1.
       { iFrame. iApply (big_sepM_sep with "[$Hregs Hregs_val]"). cbn beta.
@@ -238,19 +238,19 @@ Section counter.
     apply contiguous_between_cons_inv_first in Hcont as Heq. subst a.
     (* Get a general purpose register *)
     assert (is_Some (rmap !! r_ret)) as [w' Hrtret].
-    { apply elem_of_gmap_dom. rewrite Hdom. apply elem_of_difference.
+    { apply elem_of_dom. rewrite Hdom. apply elem_of_difference.
       split;[apply all_registers_s_correct|clear;set_solver]. }
     assert (is_Some (rmap !! r_t2)) as [w2 Hrt2].
-    { apply elem_of_gmap_dom. rewrite Hdom. apply elem_of_difference.
+    { apply elem_of_dom. rewrite Hdom. apply elem_of_difference.
       split;[apply all_registers_s_correct|clear;set_solver]. }
     assert (is_Some (rmap !! r_t3)) as [w3 Hrt3].
-    { apply elem_of_gmap_dom. rewrite Hdom. apply elem_of_difference.
+    { apply elem_of_dom. rewrite Hdom. apply elem_of_difference.
       split;[apply all_registers_s_correct|clear;set_solver]. }
     assert (is_Some (rmap !! r_t4)) as [w4 Hrt4].
-    { apply elem_of_gmap_dom. rewrite Hdom. apply elem_of_difference.
+    { apply elem_of_dom. rewrite Hdom. apply elem_of_difference.
       split;[apply all_registers_s_correct|clear;set_solver]. }
     assert (is_Some (rmap !! r_t5)) as [w5 Hrt5].
-    { apply elem_of_gmap_dom. rewrite Hdom. apply elem_of_difference.
+    { apply elem_of_dom. rewrite Hdom. apply elem_of_difference.
       split;[apply all_registers_s_correct|clear;set_solver]. }
     iDestruct (big_sepM_delete _ _ r_ret with "Hregs") as "[Hr_ret Hregs]";[eauto|].
     iDestruct "Hr_t1" as (w1) "Hr_t1".
@@ -343,12 +343,12 @@ Section counter.
     { rewrite !lookup_insert_ne;auto. repeat (rewrite lookup_delete_ne;[|by auto]). apply lookup_delete. }
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hregs $Hr_t1]") as "Hregs".
     { rewrite !lookup_insert_ne;auto. repeat (rewrite lookup_delete_ne;[|by auto]).
-      apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+      apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_ret with "[$Hregs $Hr_ret]") as "Hregs".
     { rewrite !lookup_insert_ne;auto. repeat (rewrite lookup_delete_ne;[|by auto]). apply lookup_delete. }
     iDestruct (big_sepM_insert _ _ r_env with "[$Hregs $Hr_env]") as "Hregs".
     { rewrite !lookup_insert_ne;auto. rewrite !lookup_delete_ne//.
-      apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+      apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
     repeat (repeat (rewrite -delete_insert_ne;[|by auto]);rewrite insert_delete_insert).
     set regs' := <[_:=_]> _.
     (* jump to unknown code *)
@@ -357,7 +357,7 @@ Section counter.
     iMod ("Hcls" with "[Hprog_done Hi $Hown]") as "Hown".
     { iNext. rewrite Heqapp. iFrame. iDestruct "Hprog_done" as "($&Hassert&$&$&$)". iFrame. destruct rest; inversion Hrest_length. done. }
     iDestruct (big_sepM_insert _ _ r_t0 with "[$Hregs $Hr_t0]") as "Hregs".
-    { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+    { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
     iApply (wp_wand with "[-Hφ]").
     { iApply "Hcallback_now"; cycle 1. iFrame.
       { iApply (big_sepM_sep with "[$Hregs Hregs_val]"). cbn beta.
@@ -446,9 +446,9 @@ Section counter.
 
     (* reassemble registers *)
     iDestruct (big_sepM_insert _ _ r_env with "[$Hregs $Hr_env]") as "Hregs".
-    { apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+    { apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hregs $Hr_t1]") as "Hregs".
-    { rewrite lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+    { rewrite lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
 
     set rmap' := <[_:=_]> _.
     iDestruct (jmp_to_unknown with "Hcallback") as "Hcallback_now".
@@ -456,7 +456,7 @@ Section counter.
     iMod ("Hcls" with "[Hprog_done Hi $Hown]") as "Hown".
     { iNext. iFrame. iDestruct "Hprog_done" as "($&$&$)". done. }
     iDestruct (big_sepM_insert _ _ r_t0 with "[$Hregs $Hr_t0]") as "Hregs".
-    { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+    { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
     iApply (wp_wand with "[-Hφ]").
     { iApply "Hcallback_now"; cycle 1.
       { iFrame. iApply (big_sepM_sep with "[$Hregs Hregs_val]"). cbn beta.

--- a/theories/examples/counter_binary.v
+++ b/theories/examples/counter_binary.v
@@ -8,29 +8,29 @@ Section counter.
   Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
-  
+
   (* ----------------------------------- a counter counting up --------------------------------------- *)
   Definition r_ret := r_t31.
-  
+
   Definition incr_instrs :=
     [load_r r_t1 r_env;
     add_r_z r_t1 r_t1 1;
     store_r r_env r_t1;
     move_z r_env 0;
     move_z r_t1 0; (* we now need to erase internal details about the counter! *)
-    jmp r_t0]. 
+    jmp r_t0].
 
   Definition read_instrs :=
     [load_r r_ret r_env;
     move_z r_env 0;
     move_z r_t1 0; (* the closure activation will have a copy of the PC in r_t1, so we need to clear it *)
-    jmp r_t0]. 
+    jmp r_t0].
 
   Definition incr_left a :=
     ([∗ list] a_i;w ∈ a;incr_instrs, a_i ↦ₐ w)%I.
   Definition read_left a :=
     ([∗ list] a_i;w ∈ a;read_instrs, a_i ↦ₐ w)%I.
-  
+
   (* ---------------------------------- a counter counting down -------------------------------------- *)
 
   Definition decr_instrs :=
@@ -40,7 +40,7 @@ Section counter.
     move_z r_env 0;
     move_z r_t1 0; (* we now need to erase internal details about the counter! *)
     jmp r_t0].
-  
+
   (* The following read function returns the positive of r_env *)
   (* Assumption: r_env contains a negative integer *)
   Definition read_neg_instrs :=
@@ -48,13 +48,13 @@ Section counter.
     sub_z_r r_ret 0 r_ret;
     move_z r_env 0;
     move_z r_t1 0; (* the closure activation will have a copy of the PC in r_t1, so we need to clear it *)
-    jmp r_t0]. 
+    jmp r_t0].
 
   Definition decr_right a :=
     ([∗ list] a_i;w ∈ a;decr_instrs, a_i ↣ₐ w)%I.
   Definition read_right a :=
-    ([∗ list] a_i;w ∈ a;read_neg_instrs, a_i ↣ₐ w)%I. 
-  
+    ([∗ list] a_i;w ∈ a;read_neg_instrs, a_i ↣ₐ w)%I.
+
 
   (* ---------------------------------- the counter invariant -------------------------------------- *)
 
@@ -62,7 +62,7 @@ Section counter.
     (∃ z, d ↦ₐ WInt z ∗ ds ↣ₐ WInt (-z)%Z)%I.
 
   (* ----------------------------------- INCR -------------------------------------- *)
-  
+
   Lemma incr_spec pc_p pc_b pc_e pcs_p pcs_b pcs_e (* PC *)
         wret wret' (* return cap *)
         incr_addrs decr_addrs (* program addresses *)
@@ -78,7 +78,7 @@ Section counter.
     (* Program adresses assumptions *)
     contiguous_between incr_addrs a_first a_last ->
     contiguous_between decr_addrs s_first s_last ->
-    
+
     (* malloc'ed memory assumption for the counter *)
     (d + 1)%a = Some d' ->
     (ds + 1)%a = Some ds' ->
@@ -88,7 +88,7 @@ Section counter.
     dom smap = all_registers_s ∖ {[PC;r_t0;r_env;r_t1]} →
 
     nclose specN ## ↑ι →
-    
+
     {{{ spec_ctx
       ∗ PC ↦ᵣ WCap pc_p pc_b pc_e a_first ∗ PC ↣ᵣ WCap pcs_p pcs_b pcs_e s_first
       ∗ r_t0 ↦ᵣ wret ∗ r_t0 ↣ᵣ wret'
@@ -115,117 +115,117 @@ Section counter.
                          ∗ na_own logrel_nais ⊤ }}}.
   Proof.
     iIntros (Hvpc1 Hvpc2 Hcont1 Hcont2 Hd1 Hd2 Hdom1 Hdom2 Hnclose φ)
-            "(#Hspec & HPC & HsPC & Hr_t0 & Hs_t0 & Hr_env & Hs_env 
-            & Hr_t1 & Hs_t1 & Hrmap & Hsmap & Hj & #Hcounter 
+            "(#Hspec & HPC & HsPC & Hr_t0 & Hs_t0 & Hr_env & Hs_env
+            & Hr_t1 & Hs_t1 & Hrmap & Hsmap & Hj & #Hcounter
             & Hown & #Hcont & #Hprogs & #Hregs_valid) Hφ".
     iMod (na_inv_acc with "Hprogs Hown") as "(>(Hprog & Hsprog) & Hown & Hcls)";auto.
     iDestruct (big_sepL2_length with "Hprog") as %Hprog_length.
     iDestruct (big_sepL2_length with "Hsprog") as %Hsprog_length.
     destruct_list incr_addrs. destruct_list decr_addrs.
-    apply contiguous_between_cons_inv_first in Hcont1 as Heq. subst a. 
-    apply contiguous_between_cons_inv_first in Hcont2 as Heq. subst a5. 
+    apply contiguous_between_cons_inv_first in Hcont1 as Heq. subst a.
+    apply contiguous_between_cons_inv_first in Hcont2 as Heq. subst a5.
     (* Get a general purpose register *)
     iDestruct "Hr_t1" as (w1) "Hr_t1".
-    iDestruct "Hs_t1" as (w1') "Hs_t1". 
+    iDestruct "Hs_t1" as (w1') "Hs_t1".
     (* load r_t1 r_env *)
-    iPrologue_both "Hprog" "Hsprog". rewrite /counter_inv. 
+    iPrologue_both "Hprog" "Hsprog". rewrite /counter_inv.
     iInv ι as (z) "[>Hd >Hds]" "Hcls'".
     iApply (wp_load_success_notinstr with "[$HPC $Hi $Hr_t1 $Hr_env $Hd]");
-      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last| |iContiguous_next Hcont1 0|..]. 
+      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last| |iContiguous_next Hcont1 0|..].
     { split;auto. simpl. apply andb_true_iff. rewrite Z.leb_le Z.ltb_lt. clear -Hd1;solve_addr. }
     iNext. iIntros "(HPC & Hr_t1 & Hprog_done & Hr_env & Hd)".
     iMod (step_load_success_alt _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t1 $Hs_env $Hds]")
       as "(Hj & HsPC & Hs_t1 & Hsprog_done & Hs_env & Hds)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last| |iContiguous_next Hcont2 0|solve_ndisj|..]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last| |iContiguous_next Hcont2 0|solve_ndisj|..].
     { split;auto. simpl. apply andb_true_iff. rewrite Z.leb_le Z.ltb_lt. clear -Hd2;solve_addr. }
-    iMod ("Hcls'" with "[Hd Hds]") as "_". 
+    iMod ("Hcls'" with "[Hd Hds]") as "_".
     { iNext. iExists z. iFrame "∗ #". }
     iModIntro. iApply wp_pure_step_later;auto;iNext;iIntros "_".
-    iMod (do_step_pure _ [] with "[$Hspec $Hj]") as "Hj /=";[auto|]. 
+    iMod (do_step_pure _ [] with "[$Hspec $Hj]") as "Hj /=";[auto|].
     (* add r_t1 r_t1 1 || sub r_t1 r_t1 1 *)
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_add_sub_lt_success_dst_z _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t1]")
       as "(Hj & HsPC & Hsi & Hs_t1)";
-      [apply decode_encode_instrW_inv|eauto|iContiguous_next Hcont2 1|iCorrectPC s_first s_last|solve_ndisj|]. 
-    iApply (wp_add_sub_lt_success_dst_z with "[$HPC $Hi $Hr_t1]"); 
-      [apply decode_encode_instrW_inv|eauto|iContiguous_next Hcont1 1|iCorrectPC a_first a_last|]. 
+      [apply decode_encode_instrW_inv|eauto|iContiguous_next Hcont2 1|iCorrectPC s_first s_last|solve_ndisj|].
+    iApply (wp_add_sub_lt_success_dst_z with "[$HPC $Hi $Hr_t1]");
+      [apply decode_encode_instrW_inv|eauto|iContiguous_next Hcont1 1|iCorrectPC a_first a_last|].
     iEpilogue_both "(HPC & Hi & Hr_t1) /=". iCombinePtrn.
     (* store r_env r_t1 *)
     iPrologue_both "Hprog" "Hsprog".
-    iInv ι as (z') "[>Hd >Hds]" "Hcls'". 
+    iInv ι as (z') "[>Hd >Hds]" "Hcls'".
     iMod (step_store_success_reg _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t1 $Hs_env $Hds]")
       as "(Hj & HsPC & Hsi & Hs_t1 & Hs_env & Hds)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 2| |solve_ndisj|..]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 2| |solve_ndisj|..].
     { split;auto. simpl. apply andb_true_iff. rewrite Z.leb_le Z.ltb_lt. clear -Hd2;solve_addr. }
     iApply (wp_store_success_reg with "[$HPC $Hi $Hr_t1 $Hr_env $Hd]");
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 2|..].
     { auto. }
     { simpl. apply andb_true_iff. rewrite Z.leb_le Z.ltb_lt. clear -Hd1;solve_addr. }
     iNext. iIntros "(HPC & Hi & Hr_t1 & Hr_env & Hd)".
-    iMod ("Hcls'" with "[Hd Hds]") as "_". 
+    iMod ("Hcls'" with "[Hd Hds]") as "_".
     { iNext. iExists ((z + 1)%Z). assert ((- z - 1)%Z = (- (z + 1))%Z) as ->;[clear;lia|]. iFrame. }
     iModIntro. iApply wp_pure_step_later;auto;iNext;iIntros "_".
     iMod (do_step_pure _ [] with "[$Hspec $Hj]") as "Hj /=";[auto|]. iCombinePtrn.
     (* move r_env 0 *)
-    iPrologue_both "Hprog" "Hsprog". 
+    iPrologue_both "Hprog" "Hsprog".
     iMod (step_move_success_z _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_env]")
       as "(Hj & HsPC & Hsi & Hs_env)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 3|auto|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 3|auto|].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_env]");
-      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 3|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 3|].
     iEpilogue_both "(HPC & Hi & Hr_env)". iCombinePtrn.
     (* move r_env 0 *)
-    iPrologue_both "Hprog" "Hsprog". 
+    iPrologue_both "Hprog" "Hsprog".
     iMod (step_move_success_z _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t1]")
       as "(Hj & HsPC & Hsi & Hs_t1)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 4|auto|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 4|auto|].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_t1]");
-      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 4|]. 
-    iEpilogue_both "(HPC & Hi & Hr_t1)". iCombinePtrn. 
+      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 4|].
+    iEpilogue_both "(HPC & Hi & Hr_t1)". iCombinePtrn.
     (* jmp r_t0 *)
-    iPrologue_both "Hprog" "Hsprog". 
+    iPrologue_both "Hprog" "Hsprog".
     apply (contiguous_between_last _ _ _ a4) in Hcont1 as Hlast;auto.
-    apply (contiguous_between_last _ _ _ a10) in Hcont2 as Hlast';auto. 
+    apply (contiguous_between_last _ _ _ a10) in Hcont2 as Hlast';auto.
     iMod (step_jmp_success _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t0]")
       as "(Hj & HsPC & Hsi & Hs_t0)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|auto|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|auto|].
     iApply (wp_jmp_success with "[$HPC $Hi $Hr_t0]");
-      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|]. 
-    iDestruct (jmp_or_fail_spec with "Hspec Hcont") as "Hcallback_now". 
+      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|].
+    iDestruct (jmp_or_fail_spec with "Hspec Hcont") as "Hcallback_now".
 
     (* reassemble registers *)
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hrmap $Hr_t1]") as "Hrmap".
-    { apply elem_of_gmap_dom_none. rewrite Hdom1. clear; set_solver. }
+    { apply not_elem_of_dom. rewrite Hdom1. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hsmap $Hs_t1]") as "Hsmap".
-    { apply elem_of_gmap_dom_none. rewrite Hdom2. clear; set_solver. }
+    { apply not_elem_of_dom. rewrite Hdom2. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_env with "[$Hrmap $Hr_env]") as "Hrmap".
-    { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom1. clear; set_solver. }
+    { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom1. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_env with "[$Hsmap $Hs_env]") as "Hsmap".
-    { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom2. clear; set_solver. }
-    
+    { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom2. clear; set_solver. }
+
     (* now we are ready to apply the jump or fail pattern *)
-    destruct (decide (isCorrectPC (updatePcPerm wret))). 
-    - iDestruct "Hcallback_now" as (p b e a Heq) "Hcallback'". 
+    destruct (decide (isCorrectPC (updatePcPerm wret))).
+    - iDestruct "Hcallback_now" as (p b e a Heq) "Hcallback'".
       simplify_eq.
       iEpilogue_both "(HPC & Hi & Hr_t0)".
       iMod ("Hcls" with "[Hprog_done Hsprog_done Hi Hsi $Hown]") as "Hown".
       { iNext. iFrame. iDestruct "Hprog_done" as "($&$&$&$&$)". iDestruct "Hsprog_done" as "($&$&$&$&$)". iSplit; done. }
       iDestruct (big_sepM_insert _ _ r_t0 with "[$Hrmap $Hr_t0]") as "Hrmap".
-      { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom1. clear; set_solver. }
+      { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom1. clear; set_solver. }
       iDestruct (big_sepM_insert _ _ r_t0 with "[$Hsmap $Hs_t0]") as "Hsmap".
-      { rewrite !lookup_insert_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom2. clear; set_solver. }
-      iDestruct (interp_eq with "Hcont") as %<-. 
+      { rewrite !lookup_insert_ne;auto. apply not_elem_of_dom. rewrite Hdom2. clear; set_solver. }
+      iDestruct (interp_eq with "Hcont") as %<-.
       set (regs' := <[PC:=WInt 0%Z]> (<[r_t0:=WCap p b e a]> (<[r_env:=WInt 0%Z]> (<[r_t1:=WInt 0%Z]> rmap)))).
       set (segs' := <[PC:=WInt 0%Z]> (<[r_t0:=WCap p b e a]> (<[r_env:=WInt 0%Z]> (<[r_t1:=WInt 0%Z]> smap)))).
-      iDestruct ("Hcallback'" $! (regs',segs') with "[Hrmap Hsmap $Hj $Hown HPC HsPC]") as "[_ Hexpr]". 
+      iDestruct ("Hcallback'" $! (regs',segs') with "[Hrmap Hsmap $Hj $Hown HPC HsPC]") as "[_ Hexpr]".
       { rewrite /registers_mapsto /spec_registers_mapsto /regs' /segs'.
         iSplit.
         - iClear "Hcallback' Hrmap Hsmap HPC HsPC". rewrite /interp_reg /=. iSplit.
           + iPureIntro.
-            intros r'. simpl. consider_next_reg_both r' PC. 
-            consider_next_reg_both r' r_t0. consider_next_reg_both r' r_env. 
-            consider_next_reg_both r' r_t1. 
-            split; apply elem_of_gmap_dom;[rewrite Hdom1|rewrite Hdom2];assert (r' ∈ all_registers_s) as Hin;
+            intros r'. simpl. consider_next_reg_both r' PC.
+            consider_next_reg_both r' r_t0. consider_next_reg_both r' r_env.
+            consider_next_reg_both r' r_t1.
+            split; apply elem_of_dom;[rewrite Hdom1|rewrite Hdom2];assert (r' ∈ all_registers_s) as Hin;
               [apply all_registers_s_correct| |apply all_registers_s_correct|];revert n n0 n1 n2 Hin;clear;set_solver.
           + iIntros (r v1 v2 Hne Hv1s Hv2s).
             consider_next_reg_both1 r PC Hv1s Hv2s. done.
@@ -233,21 +233,21 @@ Section counter.
             consider_next_reg_both1 r r_t1 Hv1s Hv2s. rewrite !fixpoint_interp1_eq. simplify_eq. done.
             iApply "Hregs_valid"; auto.
         - rewrite !insert_insert.
-          iSplitL "HPC Hrmap". 
+          iSplitL "HPC Hrmap".
           + iApply (big_sepM_delete _ _ PC);[apply lookup_insert|]. iFrame.
             rewrite delete_insert. iFrame.
-            repeat (rewrite lookup_insert_ne;auto). 
-            apply elem_of_gmap_dom_none. rewrite Hdom1. clear;set_solver.
+            repeat (rewrite lookup_insert_ne;auto).
+            apply not_elem_of_dom. rewrite Hdom1. clear;set_solver.
           + iApply (big_sepM_delete _ _ PC);[apply lookup_insert|]. iFrame.
             rewrite delete_insert. iFrame.
-            repeat (rewrite lookup_insert_ne;auto). 
-            apply elem_of_gmap_dom_none. rewrite Hdom2. clear;set_solver.
+            repeat (rewrite lookup_insert_ne;auto).
+            apply not_elem_of_dom. rewrite Hdom2. clear;set_solver.
       }
-      rewrite /interp_conf. iApply wp_wand_l. iFrame "Hexpr". 
+      rewrite /interp_conf. iApply wp_wand_l. iFrame "Hexpr".
       iIntros (v). iApply "Hφ".
     - iEpilogue "(HPC & Hi & Hr_t0)".
       iApply "Hcallback_now". iFrame.
-      iApply "Hφ". iIntros (Hcontr); inversion Hcontr. 
+      iApply "Hφ". iIntros (Hcontr); inversion Hcontr.
   Qed.
 
   (* ----------------------------------- READ -------------------------------------- *)
@@ -267,7 +267,7 @@ Section counter.
     (* Program adresses assumptions *)
     contiguous_between read_addrs a_first a_last ->
     contiguous_between read_neg_addrs s_first s_last ->
-    
+
     (* malloc'ed memory assumption for the counter *)
     (d + 1)%a = Some d' ->
     (ds + 1)%a = Some ds' ->
@@ -277,7 +277,7 @@ Section counter.
     dom smap = all_registers_s ∖ {[PC;r_t0;r_env;r_t1]} →
 
     nclose specN ## ↑ι →
-    
+
     {{{ spec_ctx
       ∗ PC ↦ᵣ WCap pc_p pc_b pc_e a_first ∗ PC ↣ᵣ WCap pcs_p pcs_b pcs_e s_first
       ∗ r_t0 ↦ᵣ wret ∗ r_t0 ↣ᵣ wret'
@@ -305,22 +305,22 @@ Section counter.
   Proof.
     iIntros (Hvpc1 Hvpc2 Hcont1 Hcont2 Hd Hds Hdom1 Hdom2 Hnclose φ)
             "(#Hspec & HPC & HsPC & Hr_t0 & Hs_t0 & Hr_t1 & Hs_t1 & Hr_env & Hs_env
-            & Hregs & Hsegs & Hj & #Hinv & Hown 
-            & #Hcallback & #Hread & #Hregs_val) Hφ". 
+            & Hregs & Hsegs & Hj & #Hinv & Hown
+            & #Hcallback & #Hread & #Hregs_val) Hφ".
     iMod (na_inv_acc with "Hread Hown") as "((>Hprog & >Hsprog) & Hown & Hcls)";auto.
     iDestruct (big_sepL2_length with "Hprog") as %Hprog_length.
     iDestruct (big_sepL2_length with "Hsprog") as %Hsprog_length.
     destruct_list read_addrs. destruct_list read_neg_addrs.
-    apply contiguous_between_cons_inv_first in Hcont1 as Heq. subst a. 
+    apply contiguous_between_cons_inv_first in Hcont1 as Heq. subst a.
     apply contiguous_between_cons_inv_first in Hcont2 as Heq. subst a3.
     (* Get a general purpose register *)
     assert (is_Some (rmap !! r_ret) ∧ is_Some (smap !! r_ret)) as [ [w' Hrtret] [w'' Hstret] ].
-    { split; apply elem_of_gmap_dom;[rewrite Hdom1|rewrite Hdom2];apply elem_of_difference;
+    { split; apply elem_of_dom;[rewrite Hdom1|rewrite Hdom2];apply elem_of_difference;
       split;[apply all_registers_s_correct|clear;set_solver|apply all_registers_s_correct|clear;set_solver]. }
     iDestruct (big_sepM_delete _ _ r_ret with "Hregs") as "[Hr_ret Hregs]";[eauto|].
     iDestruct (big_sepM_delete _ _ r_ret with "Hsegs") as "[Hs_ret Hsegs]";[eauto|].
     (* load r_ret r_env *)
-    iPrologue_both "Hprog" "Hsprog". 
+    iPrologue_both "Hprog" "Hsprog".
     iInv ι as (z) "[>Hd >Hds]" "Hcls'".
     iApply (wp_load_success_notinstr with "[$HPC $Hi $Hr_ret $Hr_env $Hd]");
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last| |iContiguous_next Hcont1 0|..].
@@ -328,12 +328,12 @@ Section counter.
     iNext. iIntros "(HPC & Hr_ret & Hprog_done & Hr_env & Hd)".
     iMod (step_load_success_alt _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_ret $Hs_env $Hds]")
       as "(Hj & HsPC & Hs_ret & Hsprog_done & Hs_env & Hds)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last| |iContiguous_next Hcont2 0|solve_ndisj|..]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last| |iContiguous_next Hcont2 0|solve_ndisj|..].
     { split;auto. simpl. apply andb_true_iff. rewrite Z.leb_le Z.ltb_lt. revert Hds;clear;solve_addr. }
-    iMod ("Hcls'" with "[Hd Hds]") as "_". 
+    iMod ("Hcls'" with "[Hd Hds]") as "_".
     { iNext. iExists z. iFrame "∗ #". }
     iModIntro. iApply wp_pure_step_later;auto;iNext;iIntros "_".
-    iMod (do_step_pure _ [] with "[$Hspec $Hj]") as "Hj /=";[auto|]. 
+    iMod (do_step_pure _ [] with "[$Hspec $Hj]") as "Hj /=";[auto|].
     (* SPEC ONLY: sub r_ret 0 r_ret *)
     (* This is a crucial part of the RHS such that return value will match *)
     iDestruct "Hsprog" as "[Hsi Hsprog]".
@@ -342,12 +342,12 @@ Section counter.
       [apply decode_encode_instrW_inv|eauto|iContiguous_next Hcont2 1|iCorrectPC s_first s_last|solve_ndisj|..].
     iMod (do_step_pure _ [] with "[$Hspec $Hj]") as "Hj /=";[auto|].
     iCombine "Hsi" "Hsprog_done" as "Hsprog_done".
-    assert (0 - - z = z)%Z as ->;[clear;lia|]. 
+    assert (0 - - z = z)%Z as ->;[clear;lia|].
     (* move r_env 0 *)
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_move_success_z _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_env]")
       as "(Hj & HsPC & Hsi & Hs_env)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 2|solve_ndisj|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 2|solve_ndisj|].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_env]");
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 1|].
     iEpilogue_both "(HPC & Hi & Hr_env)". iCombinePtrn.
@@ -356,49 +356,49 @@ Section counter.
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_move_success_z _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t1]")
       as "(Hj & HsPC & Hsi & Hs_t1)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 3|solve_ndisj|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 3|solve_ndisj|].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_t1]");
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 2|].
-    iEpilogue_both "(HPC & Hi & Hr_t1)". iCombinePtrn.    
+    iEpilogue_both "(HPC & Hi & Hr_t1)". iCombinePtrn.
     (* jmp r_t0 *)
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_jmp_success _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t0]")
       as "(Hj & HsPC & Hsi & Hs_t0)";
-      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|solve_ndisj|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|solve_ndisj|].
     iApply (wp_jmp_success with "[$HPC $Hi $Hr_t0]");
-      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|]. 
-    
+      [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|].
+
     (* We now want to apply the jump or fail pattern *)
-    iDestruct (jmp_or_fail_spec with "Hspec Hcallback") as "Hcallback_now". 
-    
+    iDestruct (jmp_or_fail_spec with "Hspec Hcallback") as "Hcallback_now".
+
     (* reassemble registers *)
     iDestruct (big_sepM_insert _ _ r_ret with "[$Hregs $Hr_ret]") as "Hregs";[apply lookup_delete|].
     iDestruct (big_sepM_insert _ _ r_ret with "[$Hsegs $Hs_ret]") as "Hsegs";[apply lookup_delete|].
     iDestruct (big_sepM_insert _ _ r_env with "[$Hregs $Hr_env]") as "Hregs".
-    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply elem_of_gmap_dom_none. rewrite Hdom1. clear; set_solver. }
+    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply not_elem_of_dom. rewrite Hdom1. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_env with "[$Hsegs $Hs_env]") as "Hsegs".
-    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply elem_of_gmap_dom_none. rewrite Hdom2. clear; set_solver. }
+    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply not_elem_of_dom. rewrite Hdom2. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hregs $Hr_t1]") as "Hregs".
-    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply elem_of_gmap_dom_none. rewrite Hdom1. clear; set_solver. }
+    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply not_elem_of_dom. rewrite Hdom1. clear; set_solver. }
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hsegs $Hs_t1]") as "Hsegs".
-    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply elem_of_gmap_dom_none. rewrite Hdom2. clear; set_solver. }
-    rewrite !insert_delete_insert. 
-    
+    { rewrite !lookup_insert_ne// !lookup_delete_ne//. apply not_elem_of_dom. rewrite Hdom2. clear; set_solver. }
+    rewrite !insert_delete_insert.
+
     (* now we are ready to apply the jump or fail pattern *)
-    iDestruct (interp_eq with "Hcallback") as %<-.  
-    destruct (decide (isCorrectPC (updatePcPerm wret))). 
-    - iDestruct "Hcallback_now" as (p b e a' Heq) "Hcallback'". 
+    iDestruct (interp_eq with "Hcallback") as %<-.
+    destruct (decide (isCorrectPC (updatePcPerm wret))).
+    - iDestruct "Hcallback_now" as (p b e a' Heq) "Hcallback'".
       simplify_eq.
       iEpilogue_both "(HPC & Hi & Hr_t0)".
       iMod ("Hcls" with "[Hprog_done Hsprog_done Hi Hsi $Hown]") as "Hown".
       { iNext. iFrame. iDestruct "Hprog_done" as "($&$&$&$)". iDestruct "Hsprog_done" as "($&$&$&$)". iSplit;done. }
       iDestruct (big_sepM_insert _ _ r_t0 with "[$Hregs $Hr_t0]") as "Hregs".
-      { rewrite !lookup_insert_ne//. apply elem_of_gmap_dom_none. rewrite Hdom1. clear; set_solver. }
+      { rewrite !lookup_insert_ne//. apply not_elem_of_dom. rewrite Hdom1. clear; set_solver. }
       iDestruct (big_sepM_insert _ _ r_t0 with "[$Hsegs $Hs_t0]") as "Hsegs".
-      { rewrite !lookup_insert_ne//. apply elem_of_gmap_dom_none. rewrite Hdom2. clear; set_solver. }
+      { rewrite !lookup_insert_ne//. apply not_elem_of_dom. rewrite Hdom2. clear; set_solver. }
       set (regs' := <[PC:=WInt 0%Z]> (<[r_t0:=WCap p b e a']> (<[r_t1:=WInt 0%Z]> (<[r_env:=WInt 0%Z]> (<[r_ret:=WInt z]> rmap))))).
       set (segs' := <[PC:=WInt 0%Z]> (<[r_t0:=WCap p b e a']> (<[r_t1:=WInt 0%Z]> (<[r_env:=WInt 0%Z]> (<[r_ret:=WInt z]> smap))))).
-      iDestruct ("Hcallback'" $! (regs',segs') with "[Hregs Hsegs $Hj $Hown HPC HsPC]") as "[_ Hexpr]". 
+      iDestruct ("Hcallback'" $! (regs',segs') with "[Hregs Hsegs $Hj $Hown HPC HsPC]") as "[_ Hexpr]".
       { rewrite /registers_mapsto /spec_registers_mapsto /regs' /segs'.
         iSplit.
         - iClear "Hcallback' Hregs Hsegs HsPC HPC". rewrite /interp_reg /=. iSplit.
@@ -407,29 +407,29 @@ Section counter.
             consider_next_reg_both r' PC. consider_next_reg_both r' r_t0. consider_next_reg_both r' r_t1. consider_next_reg_both r' r_env.
             consider_next_reg_both r' r_ret.
             assert (r' ∈ all_registers_s) as Hin;[apply all_registers_s_correct|].
-            split;apply elem_of_gmap_dom;[rewrite Hdom1|rewrite Hdom2];revert n n0 n1 n2 Hin;clear;set_solver.
+            split;apply elem_of_dom;[rewrite Hdom1|rewrite Hdom2];revert n n0 n1 n2 Hin;clear;set_solver.
           + iIntros (r v1 v2 Hne Hv1s Hv2s).
             consider_next_reg_both1 r PC Hv1s Hv2s. done.
             consider_next_reg_both1 r r_t0 Hv1s Hv2s. by simplify_eq. consider_next_reg_both1 r r_t1 Hv1s Hv2s. rewrite !fixpoint_interp1_eq. simplify_eq. done.
             consider_next_reg_both1 r r_env Hv1s Hv2s. rewrite !fixpoint_interp1_eq. simplify_eq. done. consider_next_reg_both1 r r_ret Hv1s Hv2s. simplify_eq. rewrite !fixpoint_interp1_eq. done.
             iApply "Hregs_val"; auto.
         - rewrite !insert_insert.
-          iSplitL "Hregs HPC". 
+          iSplitL "Hregs HPC".
           + iApply (big_sepM_delete _ _ PC);[apply lookup_insert|]. iFrame.
             rewrite delete_insert. iFrame.
-            repeat (rewrite lookup_insert_ne;auto). 
-            apply elem_of_gmap_dom_none. rewrite Hdom1. clear;set_solver.
+            repeat (rewrite lookup_insert_ne;auto).
+            apply not_elem_of_dom. rewrite Hdom1. clear;set_solver.
           + iApply (big_sepM_delete _ _ PC);[apply lookup_insert|]. iFrame.
             rewrite delete_insert. iFrame.
-            repeat (rewrite lookup_insert_ne;auto). 
-            apply elem_of_gmap_dom_none. rewrite Hdom2. clear;set_solver.
+            repeat (rewrite lookup_insert_ne;auto).
+            apply not_elem_of_dom. rewrite Hdom2. clear;set_solver.
       }
-      rewrite /interp_conf. iApply wp_wand_l. iFrame "Hexpr". 
+      rewrite /interp_conf. iApply wp_wand_l. iFrame "Hexpr".
       iIntros (v). iApply "Hφ".
     - iEpilogue "(HPC & Hi & Hr_t0)".
       iApply "Hcallback_now". iFrame.
-      iApply "Hφ". iIntros (Hcontr); inversion Hcontr. 
+      iApply "Hφ". iIntros (Hcontr); inversion Hcontr.
   Qed.
-    
-    
+
+
 End counter.

--- a/theories/examples/counter_binary_preamble.v
+++ b/theories/examples/counter_binary_preamble.v
@@ -2,7 +2,7 @@ From iris.algebra Require Import frac.
 From iris.proofmode Require Import proofmode.
 From iris.base_logic Require Import invariants.
 Require Import Eqdep_dec.
-From cap_machine Require Import rules_binary logrel_binary fundamental_binary. 
+From cap_machine Require Import rules_binary logrel_binary fundamental_binary.
 From cap_machine.examples Require Import macros macros_binary macros_helpers malloc_binary counter_binary.
 From stdpp Require Import countable.
 
@@ -16,14 +16,14 @@ Section counter_example_preamble.
     incr_instrs ++ read_instrs.
 
   Definition counter_right_instrs :=
-    decr_instrs ++ read_neg_instrs. 
+    decr_instrs ++ read_neg_instrs.
 
   Definition counter_left a :=
     ([∗ list] a_i;w ∈ a;counter_left_instrs, a_i ↦ₐ w )%I.
 
   Definition counter_right a :=
     ([∗ list] a_i;w ∈ a;counter_right_instrs, a_i ↣ₐ w )%I.
-  
+
   Definition counter_left_instrs_length : Z :=
     Eval cbv in (length (counter_left_instrs)).
   Definition incr_instrs_length : Z :=
@@ -37,7 +37,7 @@ Section counter_example_preamble.
     Eval cbv in (length (decr_instrs)).
   Definition read_neg_instrs_length : Z :=
     Eval cbv in (length (read_neg_instrs)).
-  
+
   (* [f_m] is the offset of the malloc capability *)
   (* [offset_to_counter] is the offset between the [move_r r_t1 PC] instruction
   and the code of the implementation counter, which will be the concatenation of: incr;read *)
@@ -89,12 +89,12 @@ Section counter_example_preamble.
     move_z r_t8 0;
     move_z r_t9 0;
     jmp r_t0].
-  
+
   Definition counter_left_preamble f_m offset_to_counter ai :=
     ([∗ list] a_i;w_i ∈ ai;(counter_left_preamble_instrs f_m offset_to_counter), a_i ↦ₐ w_i)%I.
   Definition counter_right_preamble f_m offset_to_counter ai :=
     ([∗ list] a_i;w_i ∈ ai;(counter_right_preamble_instrs f_m offset_to_counter), a_i ↣ₐ w_i)%I.
-  
+
   (* Compute the offset from the start of the program to the move_r r_t1 PC
      instruction. Will be used later to compute [offset_to_awkward]. *)
   (* This is somewhat overengineered, but could be easily generalized to compute
@@ -142,7 +142,7 @@ Section counter_example_preamble.
      ∗ [[b_cls',e_cls']]↦ₐ[[ [WInt v1; WInt v2; WInt v3; WInt v4; WInt v5; WInt v6; pc2; c1] ]]
      ∗ [[b_cls,e_cls]]↣ₐ[[ [WInt v1; WInt v2; WInt v3; WInt v4; WInt v5; WInt v6; pcs1; c2] ]]
      ∗ [[b_cls',e_cls']]↣ₐ[[ [WInt v1; WInt v2; WInt v3; WInt v4; WInt v5; WInt v6; pcs2; c2] ]])%I.
-  
+
   Lemma incr_decr_closure_valid incr_prog decr_prog
         restc srestc count_incrdecrN countN count_clsN
         b_cls e_cls (* incr/decr closure *)
@@ -158,52 +158,52 @@ Section counter_example_preamble.
     contiguous_between decr_prog scounter_first slinkc →
     isCorrectPC_range pc_p pc_b pc_e counter_first counter_end →
     isCorrectPC_range pcs_p pcs_b pcs_e scounter_first scounter_end →
-    
+
     contiguous_between restc linkc counter_end →
     contiguous_between srestc slinkc scounter_end →
     (b_cell + 1)%a = Some e_cell →
     (bs_cell + 1)%a = Some es_cell →
     nclose specN ## ↑countN →
-    
+
     ⊢ (spec_ctx -∗ inv countN (counter_inv b_cell bs_cell) -∗
      na_inv logrel_nais count_incrdecrN (incr_left incr_prog ∗ decr_right decr_prog) -∗
      na_inv logrel_nais count_clsN (cls_inv b_cls e_cls b_cls' e_cls' (WCap pc_p pc_b pc_e counter_first)
                                             (WCap pc_p pc_b pc_e linkc) (WCap RWX b_cell e_cell b_cell)
-                                            
+
                                             (WCap pcs_p pcs_b pcs_e scounter_first) (WCap pcs_p pcs_b pcs_e slinkc)
                                             (WCap RWX bs_cell es_cell bs_cell)) -∗
      na_own logrel_nais ⊤ -∗
     interp (WCap E b_cls e_cls b_cls,WCap E b_cls e_cls b_cls))%I.
   Proof.
     iIntros (Hnp Hnps Hcont_incr Hcont_decr Hvpc_counter Hvspc_counter Hcont_restc Hcont_srestc Hbe_cell Hbes_cell Hnclose)
-            "#Hspec #Hcounter_inv #Hincr #Hcls_inv HnaI". 
+            "#Hspec #Hcounter_inv #Hincr #Hcls_inv HnaI".
     rewrite /interp fixpoint_interp1_eq /=. iSplit;auto.
     iIntros (r') "". iNext. iModIntro.
-    iIntros "(#Hr_valid & Hregs' & Hsegs' & HnaI & Hj)". destruct r' as [r1' r2']. simpl. 
+    iIntros "(#Hr_valid & Hregs' & Hsegs' & HnaI & Hj)". destruct r' as [r1' r2']. simpl.
     iDestruct (interp_reg_eq _ _ (WCap RX b_cls e_cls b_cls) with "Hr_valid") as %Heq.
     iDestruct "Hr_valid" as "[Hr'_full Hr'_valid]"; iDestruct "Hr'_full" as %Hr'_full.
     assert (∀ x : RegName, is_Some (r1' !! x)) as Hr'_full_left;[intros x; destruct Hr'_full with x;eauto|].
-    assert (∀ x : RegName, is_Some (r2' !! x)) as Hr'_full_right;[intros x; destruct Hr'_full with x;eauto|]. 
+    assert (∀ x : RegName, is_Some (r2' !! x)) as Hr'_full_right;[intros x; destruct Hr'_full with x;eauto|].
     pose proof (regmap_full_dom _ Hr'_full_left) as Hdom_r'.
     pose proof (regmap_full_dom _ Hr'_full_right) as Hdom_s'.
-    
+
     iSplitR; [auto|]. rewrite /interp_conf.
-    
+
     iDestruct (na_inv_acc with "Hcls_inv HnaI") as ">(>(Hcls & Hcls' & Hscls & Hscls') & Hna & Hcls_close)";
       [auto..|].
-    
+
     rewrite /registers_mapsto /spec_registers_mapsto.
     rewrite -(insert_delete_insert r1') -(insert_delete_insert r2').
 
-    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete. 
+    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete.
     destruct (Hr'_full_left r_t1) as [r1v ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs'") as "[Hr1 Hregs']".
       by rewrite lookup_delete_ne //.
     destruct (Hr'_full_left r_env) as [renvv ?].
     iDestruct (big_sepM_delete _ _ r_env with "Hregs'") as "[Hrenv Hregs']".
       by rewrite !lookup_delete_ne //.
-      
-    iDestruct (big_sepM_insert with "Hsegs'") as "[HsPC Hsegs']". by apply lookup_delete. 
+
+    iDestruct (big_sepM_insert with "Hsegs'") as "[HsPC Hsegs']". by apply lookup_delete.
     destruct (Hr'_full_right r_t1) as [rs1v ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hsegs'") as "[Hs1 Hsegs']".
       by rewrite lookup_delete_ne //.
@@ -222,19 +222,19 @@ Section counter_example_preamble.
       [done| |done|auto..].
     { intros ? [? ?]. constructor; try split; auto. }
     rewrite updatePcPerm_cap_non_E //;[].
-    
+
     (* close the invariant for the closure *)
     iDestruct ("Hcls_close" with "[Hcls Hcls' Hscls Hscls' $Hna]") as ">Hna".
     { iNext. iFrame. }
-    
+
     destruct (Hr'_full_left r_t0) as [r0v Hr0v].
     iDestruct (big_sepM_delete _ _ r_t0 with "Hregs'") as "[Hr0 Hregs']".
       by rewrite !lookup_delete_ne // lookup_delete_ne //.
-      
+
    destruct (Hr'_full_right r_t0) as [s0v Hs0v].
    iDestruct (big_sepM_delete _ _ r_t0 with "Hsegs'") as "[Hs0 Hsegs']".
       by rewrite !lookup_delete_ne // lookup_delete_ne //.
-      
+
     iApply (incr_spec with "[$Hspec $Hj $HPC $HsPC $Hr0 $Hs0 $Hrenv $Hsenv $Hregs' $Hsegs' $Hna $Hincr Hr1 Hs1 $Hcounter_inv]");
       [| |apply Hcont_incr|apply Hcont_decr|auto|auto| | |apply Hnclose|..].
     { eapply isCorrectPC_range_restrict; [apply Hvpc_counter|]. split;[clear;solve_addr|].
@@ -243,7 +243,7 @@ Section counter_example_preamble.
       apply contiguous_between_bounds in Hcont_srestc. apply Hcont_srestc. }
     { rewrite !dom_delete_L Hdom_r'. clear. set_solver. }
     { rewrite !dom_delete_L Hdom_s'. clear. set_solver. }
-    { iSplitL "Hr1";[eauto|]. iSplitL;[eauto|]. iSplit. 
+    { iSplitL "Hr1";[eauto|]. iSplitL;[eauto|]. iSplit.
       - unshelve iDestruct ("Hr'_valid" $! r_t0 _ _ _ Hr0v Hs0v) as "Hval";[auto|].
         rewrite /interp//.
       - iIntros (reg v1 v2 Hne Hv1s Hv2s).
@@ -273,50 +273,50 @@ Section counter_example_preamble.
 
     contiguous_between restc counter_first linkc →
     contiguous_between srestc scounter_first slinkc →
-    
+
     (b_cell + 1)%a = Some e_cell →
     (bs_cell + 1)%a = Some es_cell →
     nclose specN ## ↑countN →
-    
+
     ⊢ (spec_ctx -∗ inv countN (counter_inv b_cell bs_cell) -∗
      na_inv logrel_nais read_readnegN (read_left read_prog ∗ read_right read_neg_prog) -∗
      na_inv logrel_nais count_clsN (cls_inv b_cls e_cls b_cls' e_cls' (WCap pc_p pc_b pc_e counter_first)
                                             (WCap pc_p pc_b pc_e linkc) (WCap RWX b_cell e_cell b_cell)
-                                            
+
                                             (WCap pcs_p pcs_b pcs_e scounter_first) (WCap pcs_p pcs_b pcs_e slinkc)
                                             (WCap RWX bs_cell es_cell bs_cell)) -∗
      na_own logrel_nais ⊤ -∗
     interp (WCap E b_cls' e_cls' b_cls',WCap E b_cls' e_cls' b_cls'))%I.
   Proof.
     iIntros (Hnp Hnps Hcont_incr Hcont_decr Hvpc_counter Hvspc_counter Hcont_restc Hcont_srestc Hbe_cell Hbes_cell Hnclose)
-            "#Hspec #Hcounter_inv #Hincr #Hcls_inv HnaI". 
+            "#Hspec #Hcounter_inv #Hincr #Hcls_inv HnaI".
     rewrite /interp fixpoint_interp1_eq /=. iSplit;auto.
     iIntros (r') "". iNext. iModIntro.
-    iIntros "(#Hr_valid & Hregs' & Hsegs' & HnaI & Hj)". destruct r' as [r1' r2']. simpl. 
+    iIntros "(#Hr_valid & Hregs' & Hsegs' & HnaI & Hj)". destruct r' as [r1' r2']. simpl.
     iDestruct (interp_reg_eq _ _ (WCap RX b_cls e_cls b_cls) with "Hr_valid") as %Heq.
     iDestruct "Hr_valid" as "[Hr'_full Hr'_valid]"; iDestruct "Hr'_full" as %Hr'_full.
     assert (∀ x : RegName, is_Some (r1' !! x)) as Hr'_full_left;[intros x; destruct Hr'_full with x;eauto|].
-    assert (∀ x : RegName, is_Some (r2' !! x)) as Hr'_full_right;[intros x; destruct Hr'_full with x;eauto|]. 
+    assert (∀ x : RegName, is_Some (r2' !! x)) as Hr'_full_right;[intros x; destruct Hr'_full with x;eauto|].
     pose proof (regmap_full_dom _ Hr'_full_left) as Hdom_r'.
     pose proof (regmap_full_dom _ Hr'_full_right) as Hdom_s'.
-    
+
     iSplitR; [auto|]. rewrite /interp_conf.
-    
+
     iDestruct (na_inv_acc with "Hcls_inv HnaI") as ">(>(Hcls & Hcls' & Hscls & Hscls') & Hna & Hcls_close)";
       [auto..|].
-    
+
     rewrite /registers_mapsto /spec_registers_mapsto.
     rewrite -(insert_delete_insert r1') -(insert_delete_insert r2').
 
-    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete. 
+    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete.
     destruct (Hr'_full_left r_t1) as [r1v ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs'") as "[Hr1 Hregs']".
       by rewrite lookup_delete_ne //.
     destruct (Hr'_full_left r_env) as [renvv ?].
     iDestruct (big_sepM_delete _ _ r_env with "Hregs'") as "[Hrenv Hregs']".
       by rewrite !lookup_delete_ne //.
-      
-    iDestruct (big_sepM_insert with "Hsegs'") as "[HsPC Hsegs']". by apply lookup_delete. 
+
+    iDestruct (big_sepM_insert with "Hsegs'") as "[HsPC Hsegs']". by apply lookup_delete.
     destruct (Hr'_full_right r_t1) as [rs1v ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hsegs'") as "[Hs1 Hsegs']".
       by rewrite lookup_delete_ne //.
@@ -335,19 +335,19 @@ Section counter_example_preamble.
       [done| |done|auto..].
     { intros ? [? ?]. constructor; try split; auto. }
     rewrite updatePcPerm_cap_non_E //;[].
-    
+
     (* close the invariant for the closure *)
     iDestruct ("Hcls_close" with "[Hcls Hcls' Hscls Hscls' $Hna]") as ">Hna".
     { iNext. iFrame. }
-    
+
     destruct (Hr'_full_left r_t0) as [r0v Hr0v].
     iDestruct (big_sepM_delete _ _ r_t0 with "Hregs'") as "[Hr0 Hregs']".
       by rewrite !lookup_delete_ne // lookup_delete_ne //.
-      
+
    destruct (Hr'_full_right r_t0) as [s0v Hs0v].
    iDestruct (big_sepM_delete _ _ r_t0 with "Hsegs'") as "[Hs0 Hsegs']".
      by rewrite !lookup_delete_ne // lookup_delete_ne //.
-   
+
    iApply (read_spec with "[$Hspec $Hj $HPC $HsPC $Hr0 $Hs0 $Hrenv $Hsenv $Hregs' $Hsegs' $Hna $Hincr Hr1 Hs1 $Hcounter_inv]");
       [| |apply Hcont_incr|apply Hcont_decr|auto|auto| | |apply Hnclose|..].
     { eapply isCorrectPC_range_restrict; [apply Hvpc_counter|]. split;[|clear;solve_addr].
@@ -356,7 +356,7 @@ Section counter_example_preamble.
       apply contiguous_between_bounds in Hcont_srestc. apply Hcont_srestc. }
     { rewrite !dom_delete_L Hdom_r'. clear. set_solver. }
     { rewrite !dom_delete_L Hdom_s'. clear. set_solver. }
-    { iSplitL "Hr1";[eauto|]. iSplitL;[eauto|]. iSplit. 
+    { iSplitL "Hr1";[eauto|]. iSplitL;[eauto|]. iSplit.
       - unshelve iDestruct ("Hr'_valid" $! r_t0 _ _ _ Hr0v Hs0v) as "Hval";[auto|]. rewrite /interp//.
       - iIntros (reg v1 v2 Hne Hv1s Hv2s).
             destruct (decide (reg = r_t0));[subst;rewrite !lookup_delete in Hv1s Hv2s;done|rewrite !(lookup_delete_ne _ r_t0) // in Hv1s, Hv2s].
@@ -376,12 +376,12 @@ Section counter_example_preamble.
   Definition count_incrN : namespace := countN .@ "incr".
   Definition count_readN : namespace := countN .@ "read".
   Definition count_clsN : namespace := countN .@ "cls".
-  Definition count_env : namespace := countN .@ "env". 
-  
+  Definition count_env : namespace := countN .@ "env".
+
   Lemma counter_preamble_spec (f_m offset_to_counter: Z) r
         pc_p pc_b pc_e pcs_p pcs_b pcs_e
-        ai a_first a_end b_link e_link a_link a_entry 
-        ais s_first s_end bs_link es_link s_link s_entry 
+        ai a_first a_end b_link e_link a_link a_entry
+        ais s_first s_end bs_link es_link s_link s_entry
         mallocN b_m e_m
         ai_counter counter_first counter_end a_move
         ais_counter counter_sfirst counter_send s_move :
@@ -391,26 +391,26 @@ Section counter_example_preamble.
 
     contiguous_between ai a_first a_end →
     contiguous_between ais s_first s_end →
-    
-    
+
+
     withinBounds b_link e_link a_entry = true →
     (a_link + f_m)%a = Some a_entry →
-    
+
     withinBounds bs_link es_link s_entry = true →
     (s_link + f_m)%a = Some s_entry →
-    
-    
+
+
     (a_first + counter_preamble_move_offset)%a = Some a_move →
     (a_move + offset_to_counter)%a = Some counter_first →
     isCorrectPC_range pc_p pc_b pc_e counter_first counter_end →
     contiguous_between ai_counter counter_first counter_end →
-    
+
     (s_first + counter_preamble_move_offset)%a = Some s_move →
     (s_move + offset_to_counter)%a = Some counter_sfirst →
     isCorrectPC_range pcs_p pcs_b pcs_e counter_sfirst counter_send →
     contiguous_between ais_counter counter_sfirst counter_send →
 
-    spec_ctx 
+    spec_ctx
     (* Code of the preambles *)
     ∗ counter_left_preamble f_m offset_to_counter ai
     ∗ counter_right_preamble f_m offset_to_counter ais
@@ -439,7 +439,7 @@ Section counter_example_preamble.
     iDestruct "Hr_full" as %Hr_full.
     rewrite /full_map.
     iSplitR; auto. rewrite /interp_conf.
-    
+
     (* put the code for the counter example in an invariant *)
     (* we separate the invariants into its tree functions *)
     iDestruct (contiguous_between_program_split with "Hcounter") as (incr_prog restc linkc)
@@ -454,11 +454,11 @@ Section counter_example_preamble.
     iDestruct (big_sepL2_length with "Hreadneg") as %readneg_length.
 
     iCombine "Hincr" "Hdecr" as "Hincr".
-    iCombine "Hread" "Hreadneg" as "Hread". 
-    
+    iCombine "Hread" "Hreadneg" as "Hread".
+
     iDestruct (na_inv_alloc logrel_nais _ count_incrN with "Hincr") as ">#Hincr".
     iDestruct (na_inv_alloc logrel_nais _ count_readN with "Hread") as ">#Hread".
-    
+
     rewrite /registers_mapsto /spec_registers_mapsto.
     iDestruct (big_sepM_delete _ _ PC with "Hregs") as "[HPC Hregs]".
       by rewrite lookup_insert //. rewrite delete_insert_delete //.
@@ -468,13 +468,13 @@ Section counter_example_preamble.
     iDestruct (big_sepM_delete _ _ r_t0 with "Hregs") as "[Hr0 Hregs]". by rewrite !lookup_delete_ne//.
     iDestruct (big_sepM_delete _ _ r_t0 with "Hsegs") as "[Hs0 Hsegs]". by rewrite !lookup_delete_ne//.
     assert (∀ x : RegName, is_Some (r.1 !! x)) as Hr'_full_left;[intros x; destruct Hr_full with x;eauto|].
-    assert (∀ x : RegName, is_Some (r.2 !! x)) as Hr'_full_right;[intros x; destruct Hr_full with x;eauto|]. 
+    assert (∀ x : RegName, is_Some (r.2 !! x)) as Hr'_full_right;[intros x; destruct Hr_full with x;eauto|].
     pose proof (regmap_full_dom _ Hr'_full_left) as Hdom_r'.
     pose proof (regmap_full_dom _ Hr'_full_right) as Hdom_s'.
-    
+
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
     iDestruct (big_sepL2_length with "Hsprog") as %Hslength.
-    
+
     assert (pc_p ≠ E).
     { eapply isCorrectPC_range_perm_non_E. eapply Hvpc.
       pose proof (contiguous_between_length _ _ _ Hcont) as HH. rewrite Hlength /= in HH.
@@ -484,7 +484,7 @@ Section counter_example_preamble.
     { eapply isCorrectPC_range_perm_non_E. eapply Hvpc'.
       pose proof (contiguous_between_length _ _ _ Hcont') as HH. rewrite Hslength /= in HH.
       revert HH; clear; solve_addr. }
-    
+
     (* malloc 1 *)
     iDestruct (contiguous_between_program_split with "Hprog") as
         (ai_malloc ai_rest a_malloc_end) "(Hmalloc & Hprog & #Hcont)"; [apply Hcont|].
@@ -492,10 +492,10 @@ Section counter_example_preamble.
     iDestruct (contiguous_between_program_split with "Hsprog") as
         (ais_malloc ais_rest as_malloc_end) "(Hsmalloc & Hsprog & #Hcont)"; [apply Hcont'|].
     iDestruct "Hcont" as %(Hcont_smalloc & Hcont_srest & Heqapp' & Hlink').
-    
+
     iDestruct (big_sepL2_length with "Hmalloc") as %Hai_malloc_len.
     iDestruct (big_sepL2_length with "Hsmalloc") as %Hais_malloc_len.
-    
+
     assert (isCorrectPC_range pc_p pc_b pc_e a_first a_malloc_end) as Hvpc1.
     { eapply isCorrectPC_range_restrict. apply Hvpc.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest). clear; solve_addr. }
@@ -508,7 +508,7 @@ Section counter_example_preamble.
     assert (isCorrectPC_range pcs_p pcs_b pcs_e as_malloc_end s_end) as Hvpc2'.
     { eapply isCorrectPC_range_restrict. apply Hvpc'.
       generalize (contiguous_between_bounds _ _ _ Hcont_smalloc). clear; solve_addr. }
-    
+
     rewrite - !/(malloc _ _ _).
     iApply (wp_wand with "[-]").
     iApply (malloc_s_spec with "[- $Hspec $Hj $HPC $HsPC $Hmalloc $Hsmalloc $Hpc_b $Hpcs_b $Ha_entry $Hs_entry $Hr0 $Hs0 $Hregs $Hsegs $Hinv_malloc $HnaI]");
@@ -522,7 +522,7 @@ Section counter_example_preamble.
     iDestruct (big_sepL2_length with "Hprog") as %Hlength_rest.
     iDestruct (big_sepL2_length with "Hsprog") as %Hlength_srest.
     2: { iIntros (?) "[HH | ->]". iApply "HH". iIntros (Hv). inversion Hv. }
-    
+
     destruct ai_rest as [| a l]; [by inversion Hlength|].
     destruct ais_rest as [| a' l']; [by inversion Hslength|].
     pose proof (contiguous_between_cons_inv_first _ _ _ _ Hcont_rest) as ->.
@@ -555,7 +555,7 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC as_malloc_end s_end|iContiguous_next Hcont_srest 1|auto..].
     iApply (wp_move_success_reg _ _ _ _ _ _ _ r_t2 _ r_t1 with "[$HPC $Hi $Hr1 $Hr2]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_malloc_end a_end|iContiguous_next Hcont_rest 1|..].
-    iEpilogue_both "(HPC & Hi & Hr2 & Hr1)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr2 & Hr1)". iCombinePtrn.
     (* move_r r_t1 PC *)
     destruct l as [| ? l]; [by inversion Hlength_rest|]. destruct l' as [| ? l']; [by inversion Hlength_srest|].
     iPrologue_both "Hprog" "Hsprog".
@@ -564,7 +564,7 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC as_malloc_end s_end|iContiguous_next Hcont_srest 2|auto..].
     iApply (wp_move_success_reg_fromPC with "[$HPC $Hi $Hr1]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_malloc_end a_end|iContiguous_next Hcont_rest 2|..].
-    iEpilogue_both "(HPC & Hi & Hr1)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr1)". iCombinePtrn.
     (* move_r r_t8 r_t2 *)
     destruct Hr_full with r_t8 as [ [? Hrt8] [? Hst8] ].
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]".
@@ -578,7 +578,7 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC as_malloc_end s_end|iContiguous_next Hcont_srest 3|auto..].
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr_t8 $Hr2]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_malloc_end a_end|iContiguous_next Hcont_rest 3|..].
-    iEpilogue_both "(HPC & Hi & Hr_t8 & Hr2)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t8 & Hr2)". iCombinePtrn.
     iDestruct (big_sepM_insert _ _ r_t8 with "[$Hregs $Hr_t8]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     iDestruct (big_sepM_insert _ _ r_t8 with "[$Hsegs $Hs_t8]") as "Hsegs";[apply lookup_delete|rewrite insert_delete_insert].
     (* move_r r_t9 r_t1 *)
@@ -594,12 +594,12 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC as_malloc_end s_end|iContiguous_next Hcont_srest 4|auto..].
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr_t8 $Hr1]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_malloc_end a_end|iContiguous_next Hcont_rest 4|..].
-    iEpilogue_both "(HPC & Hi & Hr_t8 & Hr1)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t8 & Hr1)". iCombinePtrn.
     iDestruct (big_sepM_insert _ _ r_t9 with "[$Hregs $Hr_t8]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     iDestruct (big_sepM_insert _ _ r_t9 with "[$Hsegs $Hs_t8]") as "Hsegs";[apply lookup_delete|rewrite insert_delete_insert].
 
     (* lea_z r_t1 offset_to_awkward *)
-    
+
     assert (a_move' = a_move) as ->.
     { assert ((a_first + (length ai_malloc + 2))%a = Some a_move') as HH.
       { rewrite Hai_malloc_len /= in Hlink |- *.
@@ -614,7 +614,7 @@ Section counter_example_preamble.
         revert Hlink'; clear; solve_addr. }
       revert HH Ha_lea'. rewrite Hais_malloc_len. cbn. clear.
       unfold counter_preamble_move_offset. solve_addr. }
-    
+
     destruct l as [| ? l]; [by inversion Hlength_rest|]. destruct l' as [| ? l']; [by inversion Hlength_srest|].
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_lea_success_z _ [SeqCtx] _ _ _ _ _ _ _ _ _ _ _ _ counter_sfirst with "[$Hspec $Hj $HsPC $Hsi $Hs1]")
@@ -626,9 +626,9 @@ Section counter_example_preamble.
        |assumption|done|..].
     (* { destruct (isCorrectPC_range_perm _ _ _ _ _ _ Hvpc) as [-> | [-> | ->] ]; auto. *)
     (*   generalize (contiguous_between_middle_bounds _ (length ai_malloc) a_malloc_end _ _ Hcont ltac:(subst ai; rewrite list_lookup_middle; auto)). clear. solve_addr. } *)
-    iEpilogue_both "(HPC & Hi & Hr1)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr1)". iCombinePtrn.
     (* crtcls *)
-    
+
     iDestruct (contiguous_between_program_split with "Hprog") as
         (ai_crtcls ai_rest a_crtcls_end) "(Hcrtcls & Hprog & #Hcont)".
     { epose proof (contiguous_between_incr_addr _ 6%nat _ _ _ Hcont_rest eq_refl).
@@ -641,12 +641,12 @@ Section counter_example_preamble.
       eapply contiguous_between_app with (a1:=[_;_;_;_;_;_]). 2: eapply Hcont_srest.
       all: eauto. }
     iDestruct "Hcont" as %(Hcont_scrtcls & Hcont_rest1' & Heqapp1' & Hlink1').
-    
+
     assert (a_malloc_end <= f7)%a as Ha1_after_malloc.
     { eapply contiguous_between_middle_bounds'. apply Hcont_rest. repeat constructor. }
     assert (as_malloc_end <= f8)%a as Ha1_after_malloc'.
     { eapply contiguous_between_middle_bounds'. apply Hcont_srest. repeat constructor. }
-    
+
     iApply (wp_wand with "[-]").
     iApply (crtcls_spec with "[- $Hspec $Hj $HPC $HsPC $Hcrtcls $Hscrtcls $Hpc_b $Hpcs_b $Ha_entry $Hs_entry $Hr0 $Hs0 $Hregs $Hsegs $Hr1 $Hs1 $Hr2 $Hs2 $HnaI $Hinv_malloc]");
       [| |apply Hcont_crtcls|apply Hcont_scrtcls|apply Hwb_malloc|apply Ha_entry|apply Hwb_malloc'|apply Hs_entry| | |done|auto|..].
@@ -665,31 +665,31 @@ Section counter_example_preamble.
     iDestruct (big_sepL2_length with "Hsprog") as %Hlength_rest1'.
 
     (* register map cleanup *)
-    
+
     assert (forall (r : gmap RegName Word) w1 w2, <[r_t3:=WInt 0%Z]> (<[r_t4:=WInt 0%Z]> (<[r_t5:=WInt 0%Z]> (<[r_t6:=WInt 0%Z]> (<[r_t7:=WInt 0%Z]>
                   (<[r_t9:=w1]> (<[r_t8:=w2]>
                   (delete r_t2 (<[r_t3:=WInt 0%Z]> (<[r_t4:=WInt 0%Z]> (<[r_t5:=WInt 0%Z]> (delete r_t1 (delete r_t0 (delete PC r))))))))))))) =
                  <[r_t9:=w1]> (<[r_t8:=w2]> (<[r_t3:=WInt 0%Z]> (<[r_t4:=WInt 0%Z]>
                   (<[r_t5:=WInt 0%Z]> (<[r_t6:=WInt 0%Z]> (<[r_t7:=WInt 0%Z]> (delete r_t2 (delete r_t1 (delete r_t0 (delete PC r))))))))))
-           ) as Heqregs1. 
+           ) as Heqregs1.
     { clear. intros r w1 w2. set (regs := <[r_t9:=w1]> (<[r_t8:=w2]>
                                      (<[r_t3:=WInt 0%Z]> (<[r_t4:=WInt 0%Z]> (<[r_t5:=WInt 0%Z]> (<[r_t6:=WInt 0%Z]> (<[r_t7:=WInt 0%Z]>
-                                       (delete r_t2 (delete r_t1 (delete r_t0 (delete PC r))))))))))). 
+                                       (delete r_t2 (delete r_t1 (delete r_t0 (delete PC r))))))))))).
       rewrite !delete_insert_ne;auto.
-      repeat (rewrite (insert_commute _ r_t3);[|by auto]). rewrite insert_insert. 
+      repeat (rewrite (insert_commute _ r_t3);[|by auto]). rewrite insert_insert.
       repeat (rewrite (insert_commute _ r_t4);[|by auto]). rewrite insert_insert.
-      repeat (rewrite (insert_commute _ r_t5);[|by auto]). rewrite insert_insert. 
+      repeat (rewrite (insert_commute _ r_t5);[|by auto]). rewrite insert_insert.
       repeat (rewrite (insert_commute _ r_t6);[|by auto]). repeat (rewrite (insert_commute _ r_t7);[|by auto]).
-      auto.       
+      auto.
     }
-    
-    rewrite (Heqregs1 r.1). rewrite (Heqregs1 r.2). 
-    
-    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end a_end) as Hvpc3. 
+
+    rewrite (Heqregs1 r.1). rewrite (Heqregs1 r.2).
+
+    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end a_end) as Hvpc3.
     { eapply isCorrectPC_range_restrict. apply Hvpc2.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest1).
       revert Ha1_after_malloc Hlink1. clear; solve_addr. }
-    assert (isCorrectPC_range pcs_p pcs_b pcs_e as_crtcls_end s_end) as Hvpc3'. 
+    assert (isCorrectPC_range pcs_p pcs_b pcs_e as_crtcls_end s_end) as Hvpc3'.
     { eapply isCorrectPC_range_restrict. apply Hvpc2'.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest1').
       revert Ha1_after_malloc' Hlink1'. clear; solve_addr. }
@@ -700,21 +700,21 @@ Section counter_example_preamble.
     { rewrite !lookup_insert_ne;auto. rewrite !lookup_delete_ne;auto. eauto. }
     iDestruct (big_sepM_delete _ _ r_t10 with "Hsegs") as "[Hs_t10 Hsegs]".
     { rewrite !lookup_insert_ne;auto. rewrite !lookup_delete_ne;auto. eauto. }
-    
+
     destruct ai_rest as [| ? ai_rest]; [by inversion Hlength_rest1|].
     destruct ais_rest as [| ? ais_rest]; [by inversion Hlength_rest1'|].
     pose proof (contiguous_between_cons_inv_first _ _ _ _ Hcont_rest1) as ->.
     pose proof (contiguous_between_cons_inv_first _ _ _ _ Hcont_rest1') as ->.
     destruct ai_rest as [| ? ai_rest]; [by inversion Hlength_rest1|].
     destruct ais_rest as [| ? ais_rest]; [by inversion Hlength_rest1'|].
-    
+
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_move_success_reg _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t10 $Hs1]")
       as "(Hj & HsPC & Hsi & Hs_t10 & Hs1)";
       [eapply decode_encode_instrW_inv|iCorrectPC as_crtcls_end s_end|iContiguous_next Hcont_rest1' 0|auto..].
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr_t10 $Hr1]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end a_end|iContiguous_next Hcont_rest1 0|..].
-    iEpilogue_both "(HPC & Hi & Hr_t10 & Hr1)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t10 & Hr1)". iCombinePtrn.
     iDestruct (big_sepM_insert _ _ r_t10 with "[$Hregs $Hr_t10]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     iDestruct (big_sepM_insert _ _ r_t10 with "[$Hsegs $Hs_t10]") as "Hsegs";[apply lookup_delete|rewrite insert_delete_insert].
     (* move r_t2 r_t8 *)
@@ -729,7 +729,7 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC as_crtcls_end s_end|iContiguous_next Hcont_rest1' 1|auto..].
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr2 $Hr_t8]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end a_end|iContiguous_next Hcont_rest1 1|..].
-    iEpilogue_both "(HPC & Hi & Hr2 & Hr_t8)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr2 & Hr_t8)". iCombinePtrn.
     iDestruct (big_sepM_insert _ _ r_t8 with "[$Hregs $Hr_t8]") as "Hregs";[apply lookup_delete|].
     rewrite insert_delete_insert (insert_commute _ r_t8 r_t10) // (insert_commute _ r_t8 r_t9)// insert_insert.
     iDestruct (big_sepM_insert _ _ r_t8 with "[$Hsegs $Hs_t8]") as "Hsegs";[apply lookup_delete|].
@@ -759,7 +759,7 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC as_crtcls_end s_end|iContiguous_next Hcont_rest1' 3|assumption|done|auto..].
     iApply (wp_lea_success_z _ _ _ _ _ _ _ _ _ _ _ _ _ linkc with "[$HPC $Hi $Hr1]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end a_end|iContiguous_next Hcont_rest1 3|assumption|done|..].
-    iEpilogue_both "(HPC & Hi & Hr1)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr1)". iCombinePtrn.
 
     (* crtcls *)
     iDestruct (contiguous_between_program_split with "Hprog") as
@@ -768,19 +768,19 @@ Section counter_example_preamble.
       eapply contiguous_between_app with (a1:=[_;_;_;_]). 2: eapply Hcont_rest1.
       all: eauto. }
     iDestruct "Hcont" as %(Hcont_crtcls2 & Hcont_rest2 & Heqapp2 & Hlink2).
-    
+
     iDestruct (contiguous_between_program_split with "Hsprog") as
         (ais_crtcls' ais_rest' as_crtcls_end') "(Hscrtcls' & Hsprog & #Hcont)".
     { epose proof (contiguous_between_incr_addr _ 4%nat _ _ _ Hcont_rest1' eq_refl).
       eapply contiguous_between_app with (a1:=[_;_;_;_]). 2: eapply Hcont_rest1'.
       all: eauto. }
     iDestruct "Hcont" as %(Hcont_crtcls2' & Hcont_rest2' & Heqapp2' & Hlink2').
-    
+
     assert (a_crtcls_end <= f15)%a as Ha1_after_crtcls.
     { eapply contiguous_between_middle_bounds'. apply Hcont_rest1. repeat constructor. }
     assert (as_crtcls_end <= f16)%a as Ha1_after_crtcls'.
     { eapply contiguous_between_middle_bounds'. apply Hcont_rest1'. repeat constructor. }
-    
+
     iApply (wp_wand with "[-]").
     iApply (crtcls_spec with "[- $Hspec $Hj $HPC $HsPC $Hcrtcls' $Hscrtcls' $Hpc_b $Hpcs_b $Ha_entry $Hs_entry $Hr0 $Hs0 $Hregs $Hsegs $Hr1 $Hs1 $Hr2 $Hs2 $HnaI $Hinv_malloc]");
       [| |apply Hcont_crtcls2|apply Hcont_crtcls2'|apply Hwb_malloc|apply Ha_entry|apply Hwb_malloc'|apply Hs_entry| | |auto|done|auto..].
@@ -797,17 +797,17 @@ Section counter_example_preamble.
     iDestruct (big_sepL2_length with "Hsprog") as %Hlength_rest2'.
     (* register map cleanup *)
     do 2 (repeat (rewrite (insert_commute _ _ r_t7);[|by auto]);rewrite insert_insert).
-    do 2 (repeat (rewrite (insert_commute _ _ r_t6);[|by auto]);rewrite insert_insert). 
+    do 2 (repeat (rewrite (insert_commute _ _ r_t6);[|by auto]);rewrite insert_insert).
     do 2 (repeat (rewrite (insert_commute _ _ r_t5);[|by auto]);rewrite insert_insert).
     do 2 (repeat (rewrite (insert_commute _ _ r_t4);[|by auto]);rewrite insert_insert).
-    do 2 (repeat (rewrite (insert_commute _ _ r_t3);[|by auto]);rewrite insert_insert). 
+    do 2 (repeat (rewrite (insert_commute _ _ r_t3);[|by auto]);rewrite insert_insert).
 
     (* FINAL CLEANUP BEFORE RETURN *)
-    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end' a_end) as Hvpc4. 
+    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end' a_end) as Hvpc4.
     { eapply isCorrectPC_range_restrict. apply Hvpc3.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest2).
       revert Ha1_after_malloc Ha1_after_crtcls Hlink2 Hlink1. clear; solve_addr. }
-    assert (isCorrectPC_range pcs_p pcs_b pcs_e as_crtcls_end' s_end) as Hvpc4'. 
+    assert (isCorrectPC_range pcs_p pcs_b pcs_e as_crtcls_end' s_end) as Hvpc4'.
     { eapply isCorrectPC_range_restrict. apply Hvpc3'.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest2').
       revert Ha1_after_malloc' Ha1_after_crtcls' Hlink2' Hlink1'. clear; solve_addr. }
@@ -820,15 +820,15 @@ Section counter_example_preamble.
     destruct ai_rest' as [| ? ai_rest']; [by inversion Hlength_rest2|].
     destruct ais_rest' as [| ? ais_rest']; [by inversion Hlength_rest2'|].
     iPrologue_both "Hprog" "Hsprog".
-    rewrite !(insert_commute _ _ r_t10);auto. 
+    rewrite !(insert_commute _ _ r_t10);auto.
     iDestruct (big_sepM_delete _ _ r_t10 with "Hregs") as "[Hr_t10 Hregs]";[apply lookup_insert|].
-    iDestruct (big_sepM_delete _ _ r_t10 with "Hsegs") as "[Hs_t10 Hsegs]";[apply lookup_insert|]. 
+    iDestruct (big_sepM_delete _ _ r_t10 with "Hsegs") as "[Hs_t10 Hsegs]";[apply lookup_insert|].
     iMod (step_move_success_reg _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs2 $Hs_t10]")
       as "(Hj & HsPC & Hsi & Hs2 & Hs_t10)";
       [eapply decode_encode_instrW_inv|iCorrectPC as_crtcls_end' s_end|iContiguous_next Hcont_rest2' 0|auto..].
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr2 $Hr_t10]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end' a_end|iContiguous_next Hcont_rest2 0|..].
-    iEpilogue_both "(HPC & Hi & Hr2 & Hr_t10)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr2 & Hr_t10)". iCombinePtrn.
     (* move r_t10 0 *)
     destruct ai_rest' as [| ? ai_rest']; [by inversion Hlength_rest2|]. destruct ais_rest' as [| ? ais_rest']; [by inversion Hlength_rest2'|].
     iPrologue_both "Hprog" "Hsprog".
@@ -837,13 +837,13 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC as_crtcls_end' s_end|iContiguous_next Hcont_rest2' 1|auto..].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_t10]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end' a_end|iContiguous_next Hcont_rest2 1|..].
-    iEpilogue_both "(HPC & Hi & Hr_t10)". iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t10)". iCombinePtrn.
     iDestruct (big_sepM_insert _ _ r_t10 with "[$Hregs $Hr_t10]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert].
     iDestruct (big_sepM_insert _ _ r_t10 with "[$Hsegs $Hs_t10]") as "Hsegs";[apply lookup_delete|rewrite insert_delete_insert insert_insert].
     (* move r_t8 0 *)
-    iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]". 
+    iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]".
     { repeat (rewrite lookup_insert_ne;[|by auto]). apply lookup_insert. }
-    iDestruct (big_sepM_delete _ _ r_t8 with "Hsegs") as "[Hs_t8 Hsegs]". 
+    iDestruct (big_sepM_delete _ _ r_t8 with "Hsegs") as "[Hs_t8 Hsegs]".
     { repeat (rewrite lookup_insert_ne;[|by auto]). apply lookup_insert. }
     destruct ai_rest' as [| ? ai_rest']; [by inversion Hlength_rest2|]. destruct ais_rest' as [| ? ais_rest']; [by inversion Hlength_rest2'|].
     iPrologue_both "Hprog" "Hsprog".
@@ -856,9 +856,9 @@ Section counter_example_preamble.
     iDestruct (big_sepM_insert _ _ r_t8 with "[$Hregs $Hr_t8]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     iDestruct (big_sepM_insert _ _ r_t8 with "[$Hsegs $Hs_t8]") as "Hsegs";[apply lookup_delete|rewrite insert_delete_insert].
     (* move r_t9 0 *)
-    iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t9 Hregs]". 
+    iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t9 Hregs]".
     { repeat (rewrite lookup_insert_ne;[|by auto]). apply lookup_insert. }
-    iDestruct (big_sepM_delete _ _ r_t9 with "Hsegs") as "[Hs_t9 Hsegs]". 
+    iDestruct (big_sepM_delete _ _ r_t9 with "Hsegs") as "[Hs_t9 Hsegs]".
     { repeat (rewrite lookup_insert_ne;[|by auto]). apply lookup_insert. }
     destruct ai_rest' as [| ? ai_rest']; [by inversion Hlength_rest2|]. destruct ais_rest' as [| ? ais_rest']; [by inversion Hlength_rest2'|].
     iPrologue_both "Hprog" "Hsprog".
@@ -870,13 +870,13 @@ Section counter_example_preamble.
     iEpilogue_both "(HPC & Hi & Hr_t9)". iCombinePtrn.
     iDestruct (big_sepM_insert _ _ r_t9 with "[$Hregs $Hr_t9]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     iDestruct (big_sepM_insert _ _ r_t9 with "[$Hsegs $Hs_t9]") as "Hsegs";[apply lookup_delete|rewrite insert_delete_insert].
-    
+
     (* WE WILL NOW PREPARE THΕ JUMP *)
     iCombine "Hbes_cls" "Hbes_cls'" as "Hbes_cls".
-    iCombine "Hbe_cls'" "Hbes_cls" as "Hbe_cls'". 
+    iCombine "Hbe_cls'" "Hbes_cls" as "Hbe_cls'".
     iCombine "Hbe_cls" "Hbe_cls'" as "Hbe_cls".
     iDestruct (na_inv_alloc logrel_nais _ count_clsN with "Hbe_cls") as ">#Hcls_inv".
-    
+
     (* in preparation of jumping, we allocate the counter invariant *)
     (* in this closure creation, the two programs have the same address as the counter. This is not necessary however! *)
     iDestruct (inv_alloc countN _ (counter_inv b_cell b_cell) with "[Hb_cell Hb_scell]") as ">#Hcounter_inv".
@@ -894,29 +894,29 @@ Section counter_example_preamble.
       [apply decode_encode_instrW_inv|iCorrectPC as_crtcls_end' s_end|auto..].
     iApply (wp_jmp_success with "[$HPC $Hi $Hr0]");
       [apply decode_encode_instrW_inv|iCorrectPC a_crtcls_end' a_end|..].
-    
+
     (* the current state of registers is valid *)
     iAssert (interp (WCap E b_cls e_cls b_cls,WCap E b_cls e_cls b_cls))%I as "#Hvalid_cls".
     { iApply (incr_decr_closure_valid with "Hspec Hcounter_inv Hincr Hcls_inv");auto.
       apply Hvpc_counter. apply Hvpc_counter'. apply Hcont_restc. apply Hcont_restc'. solve_ndisj. }
-    
+
     iAssert (interp (WCap E b_cls' e_cls' b_cls',WCap E b_cls' e_cls' b_cls'))%I as "#Hvalid_cls'".
     { iApply (read_read_neg_closure_valid with "Hspec Hcounter_inv Hread Hcls_inv");auto.
       apply Hcont_restc. apply Hcont_restc'. apply Hvpc_counter. apply Hvpc_counter'.
       apply Hcont_incr. apply Hcont_decr. solve_ndisj. }
-    
+
     unshelve iPoseProof ("Hr_valid" $! r_t0 _ _ _ Hr0 Hs0) as "#Hr0_valid". done.
 
     (* either we fail, or we use the continuation in rt0 *)
     iDestruct (jmp_or_fail_spec with "Hspec Hr0_valid") as "Hcont".
-    destruct (decide (isCorrectPC (updatePcPerm r0))). 
+    destruct (decide (isCorrectPC (updatePcPerm r0))).
     2 : { iEpilogue_both "(HPC & Hi & Hr0)". iApply "Hcont". iFrame "HPC". iIntros (Hcontr);done. }
-    iDestruct "Hcont" as (p b e ? Heq) "#Hcont". 
-    simplify_eq. 
-    
+    iDestruct "Hcont" as (p b e ? Heq) "#Hcont".
+    simplify_eq.
+
     (* prepare the continuation *)
-    iEpilogue_both "(HPC & Hi & Hr0)". iCombinePtrn. 
-    
+    iEpilogue_both "(HPC & Hi & Hr0)". iCombinePtrn.
+
     (* Put the registers back in the map *)
     iDestruct (big_sepM_insert with "[$Hregs $Hr2]") as "Hregs".
     { repeat (rewrite lookup_insert_ne //;[]). rewrite lookup_delete //. }
@@ -942,23 +942,23 @@ Section counter_example_preamble.
     { repeat (rewrite lookup_insert_ne //;[]). rewrite lookup_delete_ne //.
       repeat (rewrite lookup_insert_ne //;[]). do 2 rewrite lookup_delete_ne //.
       apply lookup_delete. }
-    
+
     do 2 (repeat (rewrite -(delete_insert_ne _ r_t2) //;[]);rewrite insert_delete_insert).
     do 2 (repeat (rewrite -(delete_insert_ne _ r_t1) //;[]);rewrite insert_delete_insert).
     do 2 (repeat (rewrite -(delete_insert_ne _ r_t0) //;[]);rewrite insert_delete_insert).
     do 2 (repeat (rewrite -(delete_insert_ne _ PC) //;[]);rewrite insert_delete_insert).
-       
+
     rewrite -(insert_insert _ PC (updatePcPerm s0) (WInt 0%Z))  -(insert_insert _ PC _ (WInt 0%Z)).
-    
+
     match goal with |- context [ ([∗ map] k↦y ∈ <[PC:=_]> ?r, _)%I ] => set r'' := r end.
     match goal with |- context [ ([∗ map] k↦y ∈ <[PC:=updatePcPerm s0]> ?r, _)%I ] => set s'' := r end.
     iDestruct (interp_eq with "Hr0_valid") as %<-.
     iAssert (full_map (r'',s'')) as %Hr''_full.
     { rewrite /full_map. iIntros (rr). iPureIntro. split.
-      - rewrite elem_of_gmap_dom /r''.
+      - rewrite -elem_of_dom /r''.
         rewrite !dom_insert_L regmap_full_dom //.
         generalize (all_registers_s_correct rr). clear; set_solver.
-      - rewrite elem_of_gmap_dom /s''.
+      - rewrite -elem_of_dom /s''.
         rewrite !dom_insert_L regmap_full_dom //.
         generalize (all_registers_s_correct rr). clear; set_solver. }
     iSpecialize ("Hcont" $! (r'',s'') with "[$Hj $Hregs $Hsegs $HnaI]").

--- a/theories/examples/counter_preamble.v
+++ b/theories/examples/counter_preamble.v
@@ -12,10 +12,10 @@ Section counter_example_preamble.
           `{MP: MachineParameters}.
 
   Definition counter_instrs f_a :=
-    incr_instrs ++ (read_instrs f_a) ++ reset_instrs. 
+    incr_instrs ++ (read_instrs f_a) ++ reset_instrs.
 
   Definition counter f_a a :=
-    ([∗ list] a_i;w ∈ a;(counter_instrs f_a), a_i ↦ₐ w )%I. 
+    ([∗ list] a_i;w ∈ a;(counter_instrs f_a), a_i ↦ₐ w )%I.
 
   Definition counter_instrs_length : Z :=
     Eval cbv in (length (incr_instrs ++ (read_instrs 0) ++ reset_instrs)).
@@ -25,7 +25,7 @@ Section counter_example_preamble.
     Eval cbv in (length (read_instrs 0)).
   Definition reset_instrs_length : Z :=
     Eval cbv in (length (reset_instrs)).
-  
+
   (* [f_m] is the offset of the malloc capability *)
   (* [offset_to_counter] is the offset between the [move_r r_t1 PC] instruction
   and the code of the counter, which will be the concatenation of: incr;read;reset *)
@@ -59,7 +59,7 @@ Section counter_example_preamble.
     move_z r_t8 0;
     move_z r_t9 0;
     jmp r_t0].
-  
+
   Definition counter_preamble f_m offset_to_counter ai :=
     ([∗ list] a_i;w_i ∈ ai;(counter_preamble_instrs f_m offset_to_counter), a_i ↦ₐ w_i)%I.
 
@@ -99,7 +99,7 @@ Section counter_example_preamble.
 
   Definition counter_preamble_instrs_length : Z :=
     Eval cbv in (length (counter_preamble_instrs 0 0)).
-  
+
   Ltac iPrologue prog :=
     iDestruct prog as "[Hi Hprog]";
     iApply (wp_bind (fill [SeqCtx])).
@@ -112,7 +112,7 @@ Section counter_example_preamble.
     isCorrectPC_range pc_p pc_b pc_e counter_first counter_end →
     contiguous_between restc linkc counter_end →
     (b_cell + 1)%a = Some e_cell →
-    
+
     ⊢ (inv countN (counter_inv b_cell) -∗
      na_inv logrel_nais count_incrN ([∗ list] a_i;w_i ∈ incr_prog;incr_instrs, a_i ↦ₐ w_i) -∗
      na_inv logrel_nais count_clsN
@@ -122,19 +122,19 @@ Section counter_example_preamble.
      na_own logrel_nais ⊤ -∗
     interp (WCap E b_cls e_cls b_cls))%I.
   Proof.
-    iIntros (Hnp Hcont_incr Hvpc_counter Hcont_restc Hbe_cell) "#Hcounter_inv #Hincr #Hcls_inv HnaI". 
+    iIntros (Hnp Hcont_incr Hvpc_counter Hcont_restc Hbe_cell) "#Hcounter_inv #Hincr #Hcls_inv HnaI".
     rewrite /interp fixpoint_interp1_eq. rewrite /enter_cond.
     iIntros (r') "". iNext. iModIntro. rewrite /interp_expr /=.
     iIntros "([Hr'_full #Hr'_valid] & Hregs' & HnaI)". iDestruct "Hr'_full" as %Hr'_full.
     pose proof (regmap_full_dom _ Hr'_full) as Hdom_r'.
     rewrite /interp_conf.
-    
+
     iDestruct (na_inv_acc with "Hcls_inv HnaI") as ">(>(Hcls & Hcls' & Hcls'') & Hna & Hcls_close)";
       [auto..|].
-    
+
     rewrite /registers_mapsto.
     rewrite -insert_delete_insert.
-    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete. 
+    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete.
     destruct (Hr'_full r_t1) as [r1v ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs'") as "[Hr1 Hregs']".
       by rewrite lookup_delete_ne //.
@@ -150,25 +150,25 @@ Section counter_example_preamble.
     (* close the invariant for the closure *)
     iDestruct ("Hcls_close" with "[Hcls Hcls' Hcls'' $Hna]") as ">Hna".
     { iNext. iFrame. }
-    
+
     destruct (Hr'_full r_t0) as [r0v Hr0v].
     iDestruct (big_sepM_delete _ _ r_t0 with "Hregs'") as "[Hr0 Hregs']".
       by rewrite !lookup_delete_ne // lookup_delete_ne //.
-      
+
     iApply (incr_spec with "[$HPC $Hr0 $Hrenv $Hregs' $Hna $Hincr Hr1]");
       [|apply Hcont_incr|auto|..].
     { eapply isCorrectPC_range_restrict; [apply Hvpc_counter|]. split;[clear;solve_addr|].
       apply contiguous_between_bounds in Hcont_restc. apply Hcont_restc. }
     { rewrite !dom_delete_L Hdom_r'. clear. set_solver. }
-    { iSplitL;[eauto|]. iSplit. 
+    { iSplitL;[eauto|]. iSplit.
       - iExists _. iFrame "#".
       - iSplit; [unshelve iSpecialize ("Hr'_valid" $! r_t0 _ _ Hr0v); [done|]|].
         iFrame "Hr'_valid".
         iApply big_sepM_forall. iIntros (reg w Hlook).
-        assert (reg ≠ r_t0);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ r_env);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ r_t1);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ PC);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
+        assert (reg ≠ r_t0);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ r_env);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ r_t1);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ PC);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
         iSpecialize ("Hr'_valid" $! reg _ H4 Hlook).  iApply "Hr'_valid";auto.
     }
     { iNext. iIntros (?) "HH". iIntros (->). iApply "HH". eauto. }
@@ -188,7 +188,7 @@ Section counter_example_preamble.
     (up_close (B:=coPset) count_env ## ↑count_readN) →
     up_close (B:=coPset) assertN ## ↑count_readN →
     up_close (B:=coPset) assertN ## ↑count_env →
-    
+
     ⊢ (inv countN (counter_inv b_cell) -∗
      na_inv logrel_nais count_readN ([∗ list] a_i;w_i ∈ read_prog;read_instrs f_a, a_i ↦ₐ w_i) -∗
      na_inv logrel_nais count_clsN
@@ -207,13 +207,13 @@ Section counter_example_preamble.
     iIntros "([Hr'_full #Hr'_valid] & Hregs' & HnaI)". iDestruct "Hr'_full" as %Hr'_full.
     pose proof (regmap_full_dom _ Hr'_full) as Hdom_r'.
     rewrite /interp_conf.
-    
+
     iDestruct (na_inv_acc with "Hcls_inv HnaI") as ">(>(Hcls & Hcls' & Hcls'') & Hna & Hcls_close)";
       [auto..|].
-    
+
     rewrite /registers_mapsto.
     rewrite -insert_delete_insert.
-    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete. 
+    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete.
     destruct (Hr'_full r_t1) as [r1v ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs'") as "[Hr1 Hregs']".
       by rewrite lookup_delete_ne //.
@@ -229,11 +229,11 @@ Section counter_example_preamble.
     (* close the invariant for the closure *)
     iDestruct ("Hcls_close" with "[Hcls Hcls' Hcls'' $Hna]") as ">Hna".
     { iNext. iFrame. }
-    
+
     destruct (Hr'_full r_t0) as [r0v Hr0v].
     iDestruct (big_sepM_delete _ _ r_t0 with "Hregs'") as "[Hr0 Hregs']".
       by rewrite !lookup_delete_ne // lookup_delete_ne //.
-      
+
     iApply (read_spec with "[$HPC $Hr0 $Hrenv $Hregs' $Hna $Hincr Hr1 $Hlink $Hassert]");
       [|apply Hcont_read|auto..].
     { eapply isCorrectPC_range_restrict; [apply Hvpc_counter|].  apply contiguous_between_bounds in Hcont_incr.
@@ -244,14 +244,14 @@ Section counter_example_preamble.
       - iSplit; [unshelve iSpecialize ("Hr'_valid" $! r_t0 _ _ Hr0v); [done|]|].
         iFrame "Hr'_valid".
         iApply big_sepM_forall. iIntros (reg w Hlook).
-        assert (reg ≠ r_t0);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ r_env);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ r_t1);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ PC);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
+        assert (reg ≠ r_t0);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ r_env);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ r_t1);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ PC);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
         unshelve iSpecialize ("Hr'_valid" $! reg _ _ Hlook). auto. iApply "Hr'_valid";auto.
     }
     { iNext. iIntros (?) "HH". iIntros (->). iApply "HH". eauto. }
-  Qed. 
+  Qed.
 
   Lemma reset_closure_valid read_prog reset_prog incr_prog count_resetN countN count_clsN b_cls e_cls b_cls' e_cls' b_cls'' e_cls''
         pc_p pc_b pc_e counter_first counter_end linkc linkc' b_cell e_cell :
@@ -261,7 +261,7 @@ Section counter_example_preamble.
     isCorrectPC_range pc_p pc_b pc_e counter_first counter_end →
     contiguous_between reset_prog linkc' counter_end →
     (b_cell + 1)%a = Some e_cell →
-    
+
     ⊢ (inv countN (counter_inv b_cell) -∗
      na_inv logrel_nais count_resetN ([∗ list] a_i;w_i ∈ reset_prog;reset_instrs, a_i ↦ₐ w_i) -∗
      na_inv logrel_nais count_clsN
@@ -271,19 +271,19 @@ Section counter_example_preamble.
      na_own logrel_nais ⊤ -∗
     interp (WCap E b_cls'' e_cls'' b_cls''))%I.
   Proof.
-    iIntros (Hnp Hcont_incr Hcont_read Hvpc_counter Hcont_restc Hbe_cell) "#Hcounter_inv #Hincr #Hcls_inv HnaI". 
+    iIntros (Hnp Hcont_incr Hcont_read Hvpc_counter Hcont_restc Hbe_cell) "#Hcounter_inv #Hincr #Hcls_inv HnaI".
     rewrite /interp fixpoint_interp1_eq. rewrite /enter_cond.
     iIntros (r') "". iNext. iModIntro. rewrite /interp_expr /=.
     iIntros "([Hr'_full #Hr'_valid] & Hregs' & HnaI)". iDestruct "Hr'_full" as %Hr'_full.
     pose proof (regmap_full_dom _ Hr'_full) as Hdom_r'.
     rewrite /interp_conf.
-    
+
     iDestruct (na_inv_acc with "Hcls_inv HnaI") as ">(>(Hcls & Hcls' & Hcls'') & Hna & Hcls_close)";
       [auto..|].
-    
+
     rewrite /registers_mapsto.
     rewrite -insert_delete_insert.
-    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete. 
+    iDestruct (big_sepM_insert with "Hregs'") as "[HPC Hregs']". by apply lookup_delete.
     destruct (Hr'_full r_t1) as [r1v ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs'") as "[Hr1 Hregs']".
       by rewrite lookup_delete_ne //.
@@ -299,29 +299,29 @@ Section counter_example_preamble.
     (* close the invariant for the closure *)
     iDestruct ("Hcls_close" with "[Hcls Hcls' Hcls'' $Hna]") as ">Hna".
     { iNext. iFrame. }
-    
+
     destruct (Hr'_full r_t0) as [r0v Hr0v].
     iDestruct (big_sepM_delete _ _ r_t0 with "Hregs'") as "[Hr0 Hregs']".
       by rewrite !lookup_delete_ne // lookup_delete_ne //.
-      
+
     iApply (reset_spec with "[$HPC $Hr0 $Hrenv $Hregs' $Hna $Hincr Hr1]");
       [|apply Hcont_restc|auto..].
-    { eapply isCorrectPC_range_restrict; [apply Hvpc_counter|]. split;[|solve_addr]. 
+    { eapply isCorrectPC_range_restrict; [apply Hvpc_counter|]. split;[|solve_addr].
       apply contiguous_between_bounds in Hcont_incr. apply contiguous_between_bounds in Hcont_read. solve_addr. }
     { rewrite !dom_delete_L Hdom_r'. clear. set_solver. }
-    { iSplitL;[eauto|]. iSplit. 
+    { iSplitL;[eauto|]. iSplit.
       - iExists _. iFrame "#".
       - iSplit; [unshelve iSpecialize ("Hr'_valid" $! r_t0 _ _ Hr0v); [done|]|].
         iFrame "Hr'_valid".
         iApply big_sepM_forall. iIntros (reg w Hlook).
-        assert (reg ≠ r_t0);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ r_env);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ r_t1);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
-        assert (reg ≠ PC);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto]. 
+        assert (reg ≠ r_t0);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ r_env);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ r_t1);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
+        assert (reg ≠ PC);[intro Hcontr;subst;rewrite lookup_delete in Hlook;inversion Hlook|rewrite lookup_delete_ne in Hlook;auto].
         iSpecialize ("Hr'_valid" $! reg _ H4 Hlook). iApply "Hr'_valid";auto.
     }
     { iNext. iIntros (?) "HH". iIntros (->). iApply "HH". eauto. }
-  Qed. 
+  Qed.
 
 
   Definition countN : namespace := nroot .@ "awkN".
@@ -330,7 +330,7 @@ Section counter_example_preamble.
   Definition count_readN : namespace := countN .@ "read".
   Definition count_resetN : namespace := countN .@ "reset".
   Definition count_clsN : namespace := countN .@ "cls".
-  Definition count_env : namespace := countN .@ "env". 
+  Definition count_env : namespace := countN .@ "env".
 
   Lemma counter_preamble_spec (f_m f_a offset_to_counter: Z) (r: Reg) pc_p pc_b pc_e
         ai a_first a_end b_link e_link a_link a_entry a_entry'
@@ -372,7 +372,7 @@ Section counter_example_preamble.
              ([#Hr_full #Hr_valid] & Hregs & HnaI)".
     iDestruct "Hr_full" as %Hr_full.
     rewrite /full_map /interp_conf.
-    
+
     (* put the code for the counter example in an invariant *)
     (* we separate the invariants into its tree functions *)
     iDestruct (contiguous_between_program_split with "Hcounter") as (incr_prog restc linkc)
@@ -384,11 +384,11 @@ Section counter_example_preamble.
     iDestruct (big_sepL2_length with "Hincr") as %incr_length.
     iDestruct (big_sepL2_length with "Hread") as %read_length.
     iDestruct (big_sepL2_length with "Hreset") as %reset_length.
-    
+
     iDestruct (na_inv_alloc logrel_nais _ count_incrN with "Hincr") as ">#Hincr".
     iDestruct (na_inv_alloc logrel_nais _ count_readN with "Hread") as ">#Hread".
     iDestruct (na_inv_alloc logrel_nais _ count_resetN with "Hreset") as ">#Hreset".
-    
+
     rewrite /registers_mapsto.
     iDestruct (big_sepM_delete _ _ PC with "Hregs") as "[HPC Hregs]".
       by rewrite lookup_insert //. rewrite delete_insert_delete //.
@@ -396,12 +396,12 @@ Section counter_example_preamble.
     iDestruct (big_sepM_delete _ _ r_t0 with "Hregs") as "[Hr0 Hregs]". by rewrite !lookup_delete_ne//.
     pose proof (regmap_full_dom _ Hr_full) as Hdom_r.
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
-    
+
     assert (pc_p ≠ E).
     { eapply isCorrectPC_range_perm_non_E. eapply Hvpc.
       pose proof (contiguous_between_length _ _ _ Hcont) as HH. rewrite Hlength /= in HH.
       revert HH; clear; solve_addr. }
-    
+
     (* malloc 1 *)
     iDestruct (contiguous_between_program_split with "Hprog") as
         (ai_malloc ai_rest a_malloc_end) "(Hmalloc & Hprog & #Hcont)"; [apply Hcont|].
@@ -423,7 +423,7 @@ Section counter_example_preamble.
     iDestruct (region_mapsto_single with "Hcell") as (cellv) "(Hcell & _)". revert Hbe_cell; clear; solve_addr.
     iDestruct (big_sepL2_length with "Hprog") as %Hlength_rest.
     2: { iIntros (?) "[HH | ->]". iApply "HH". iIntros (Hv). inversion Hv. }
-    
+
     destruct ai_rest as [| a l]; [by inversion Hlength|].
     pose proof (contiguous_between_cons_inv_first _ _ _ _ Hcont_rest) as ->.
     (* store_z r_t1 0 *)
@@ -450,7 +450,7 @@ Section counter_example_preamble.
     iEpilogue "(HPC & Hi & Hr1)". iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* move_r r_t8 r_t2 *)
     assert (is_Some (r !! r_t8)) as [w8 Hrt8].
-    { apply elem_of_gmap_dom. rewrite Hdom_r. apply all_registers_s_correct. }
+    { apply elem_of_dom. rewrite Hdom_r. apply all_registers_s_correct. }
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]".
     { rewrite lookup_delete_ne;[|by auto]. rewrite !lookup_insert_ne;auto; rewrite !lookup_delete_ne;auto. eauto. }
     destruct l as [| ? l]; [by inversion Hlength_rest|].
@@ -461,7 +461,7 @@ Section counter_example_preamble.
     iDestruct (big_sepM_insert _ _ r_t8 with "[$Hregs $Hr_t8]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     (* move_r r_t9 r_t1 *)
     assert (is_Some (r !! r_t9)) as [w9 Hrt9].
-    { apply elem_of_gmap_dom. rewrite Hdom_r. apply all_registers_s_correct. }
+    { apply elem_of_dom. rewrite Hdom_r. apply all_registers_s_correct. }
     iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t8 Hregs]".
     { rewrite lookup_insert_ne;[|by auto]. rewrite lookup_delete_ne;auto. rewrite !lookup_insert_ne;auto; rewrite !lookup_delete_ne;auto. eauto. }
     destruct l as [| ? l]; [by inversion Hlength_rest|].
@@ -507,17 +507,17 @@ Section counter_example_preamble.
     iDestruct "HH" as (b_cls e_cls Hbe_cls) "(Hr1 & Hbe_cls & Hr0 & Hr2 & HnaI & Hregs)".
     iDestruct (big_sepL2_length with "Hprog") as %Hlength_rest'.
     (* register map cleanup *)
-    rewrite delete_insert_ne;auto. repeat (rewrite (insert_commute _ r_t3);[|by auto]). rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ r_t5);[|by auto]). rewrite -delete_insert_ne;auto. rewrite (insert_commute _ r_t5);auto. rewrite insert_insert. 
+    rewrite delete_insert_ne;auto. repeat (rewrite (insert_commute _ r_t3);[|by auto]). rewrite insert_insert.
+    repeat (rewrite (insert_commute _ r_t5);[|by auto]). rewrite -delete_insert_ne;auto. rewrite (insert_commute _ r_t5);auto. rewrite insert_insert.
     repeat (rewrite -(insert_commute _ r_t9);auto).  repeat (rewrite -(insert_commute _ r_t8);auto).
 
-    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end a_end) as Hvpc3. 
+    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end a_end) as Hvpc3.
     { eapply isCorrectPC_range_restrict. apply Hvpc2.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest').
       revert Ha1_after_malloc Hlink'. clear; solve_addr. }
     (* move r_t10 r_t1 *)
     assert (is_Some (r !! r_t10)) as [w10 Hrt10].
-    { apply elem_of_gmap_dom. rewrite Hdom_r. apply all_registers_s_correct. }
+    { apply elem_of_dom. rewrite Hdom_r. apply all_registers_s_correct. }
     iDestruct (big_sepM_delete _ _ r_t10 with "Hregs") as "[Hr_t10 Hregs]".
     { rewrite !lookup_insert_ne;auto. rewrite lookup_delete_ne;[|by auto]. rewrite !lookup_insert_ne;auto; rewrite !lookup_delete_ne;auto. eauto. }
     destruct ai_rest as [| ? ai_rest]; [by inversion Hlength_rest'|].
@@ -546,7 +546,7 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end a_end|iContiguous_next Hcont_rest' 2|..].
     iEpilogue "(HPC & Hi & Hr1 & Hr_t9)". iCombine "Hi" "Hprog_done" as "Hprog_done".
     iDestruct (big_sepM_insert _ _ r_t9 with "[$Hregs $Hr_t9]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert !(insert_commute _ _ r_t9);auto].
-    rewrite insert_insert. 
+    rewrite insert_insert.
     (* lea r_t1 offset_to_counter + length incr_instrs *)
     assert ((a_move + (offset_to_counter + (length incr_instrs)))%a = Some linkc) as H_counter_offset'.
     { revert Hlinkrestc H_counter_offset incr_length. clear. intros. solve_addr. }
@@ -576,20 +576,20 @@ Section counter_example_preamble.
     iDestruct "HH" as (b_cls' e_cls' Hbe_cls') "(Hr1 & Hbe_cls' & Hr0 & Hr2 & HnaI & Hregs)".
     iDestruct (big_sepL2_length with "Hprog") as %Hlength_rest''.
     (* register map cleanup *)
-    repeat (rewrite (insert_commute _ _ r_t3);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t4);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t6);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t7);[|by auto]);rewrite insert_insert. 
-    do 2 (rewrite delete_insert_ne;auto). repeat (rewrite (insert_commute _ _ r_t5);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t4);[|by auto]);rewrite insert_insert. 
+    repeat (rewrite (insert_commute _ _ r_t3);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t4);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t6);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t7);[|by auto]);rewrite insert_insert.
+    do 2 (rewrite delete_insert_ne;auto). repeat (rewrite (insert_commute _ _ r_t5);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t4);[|by auto]);rewrite insert_insert.
 
-    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end' a_end) as Hvpc4. 
+    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end' a_end) as Hvpc4.
     { eapply isCorrectPC_range_restrict. apply Hvpc3.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest'').
       revert Ha1_after_malloc Ha1_after_crtcls Hlink'' Hlink'. clear; solve_addr. }
     (* move r_t11 r_t1 *)
     assert (is_Some (r !! r_t11)) as [w11 Hrt11].
-    { apply elem_of_gmap_dom. rewrite Hdom_r. apply all_registers_s_correct. }
+    { apply elem_of_dom. rewrite Hdom_r. apply all_registers_s_correct. }
     iDestruct (big_sepM_delete _ _ r_t11 with "Hregs") as "[Hr_t11 Hregs]".
     { rewrite !lookup_insert_ne;auto.  rewrite !lookup_delete_ne;auto. eauto. }
     destruct ai_rest' as [| ? ai_rest']; [by inversion Hlength_rest''|].
@@ -647,22 +647,22 @@ Section counter_example_preamble.
     iDestruct "HH" as (b_cls'' e_cls'' Hbe_cls'') "(Hr1 & Hbe_cls'' & Hr0 & Hr2 & HnaI & Hregs)".
     iDestruct (big_sepL2_length with "Hprog") as %Hlength_rest'''.
     (* register map cleanup *)
-    repeat (rewrite (insert_commute _ _ r_t3);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t4);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t6);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t7);[|by auto]);rewrite insert_insert. 
-    repeat (rewrite (insert_commute _ _ r_t5);[|by auto]);rewrite insert_insert. 
-    
+    repeat (rewrite (insert_commute _ _ r_t3);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t4);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t6);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t7);[|by auto]);rewrite insert_insert.
+    repeat (rewrite (insert_commute _ _ r_t5);[|by auto]);rewrite insert_insert.
+
     (* FINAL CLEANUP BEFORE RETURN *)
-    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end'' a_end) as Hvpc5. 
+    assert (isCorrectPC_range pc_p pc_b pc_e a_crtcls_end'' a_end) as Hvpc5.
     { eapply isCorrectPC_range_restrict. apply Hvpc4.
       generalize (contiguous_between_bounds _ _ _ Hcont_rest''').
       revert Ha1_after_malloc Ha1_after_crtcls Ha1_after_crtcls' Hlink''' Hlink'' Hlink'. clear; solve_addr. }
     destruct ai_rest'' as [| ? ai_rest'']; [by inversion Hlength_rest'''|].
     pose proof (contiguous_between_cons_inv_first _ _ _ _ Hcont_rest''') as ->.
     (* move r_t2 r_t10 *)
-    rewrite !(insert_commute _ _ r_t10);auto. 
-    iDestruct (big_sepM_delete _ _ r_t10 with "Hregs") as "[Hr_t10 Hregs]";[apply lookup_insert|]. 
+    rewrite !(insert_commute _ _ r_t10);auto.
+    iDestruct (big_sepM_delete _ _ r_t10 with "Hregs") as "[Hr_t10 Hregs]";[apply lookup_insert|].
     destruct ai_rest'' as [| ? ai_rest'']; [by inversion Hlength_rest'''|].
     iPrologue "Hprog".
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr2 $Hr_t10]");
@@ -674,12 +674,12 @@ Section counter_example_preamble.
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_t10]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end'' a_end|iContiguous_next Hcont_rest''' 1|..].
     iEpilogue "(HPC & Hi & Hr_t10)". iCombine "Hi" "Hprog_done" as "Hprog_done".
-    iDestruct (big_sepM_insert _ _ r_t10 with "[$Hregs $Hr_t10]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert]. 
+    iDestruct (big_sepM_insert _ _ r_t10 with "[$Hregs $Hr_t10]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert].
     (* move r_t3 r_t11 *)
-    rewrite !(insert_commute _ _ r_t11);auto. 
+    rewrite !(insert_commute _ _ r_t11);auto.
     iDestruct (big_sepM_delete _ _ r_t11 with "Hregs") as "[Hr_t11 Hregs]";[apply lookup_insert|].
-    rewrite !(insert_commute _ _ r_t3);auto. rewrite delete_insert_ne;auto. 
-    iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]";[apply lookup_insert|]. 
+    rewrite !(insert_commute _ _ r_t3);auto. rewrite delete_insert_ne;auto.
+    iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]";[apply lookup_insert|].
     destruct ai_rest'' as [| ? ai_rest'']; [by inversion Hlength_rest'''|].
     iPrologue "Hprog".
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr_t3 $Hr_t11]");
@@ -692,28 +692,28 @@ Section counter_example_preamble.
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end'' a_end|iContiguous_next Hcont_rest''' 3|..].
     iEpilogue "(HPC & Hi & Hr_t11)". iCombine "Hi" "Hprog_done" as "Hprog_done".
     iDestruct (big_sepM_insert _ _ r_t3 with "[$Hregs $Hr_t3]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert].
-    rewrite -delete_insert_ne;auto. 
-    iDestruct (big_sepM_insert _ _ r_t11 with "[$Hregs $Hr_t11]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert]. 
+    rewrite -delete_insert_ne;auto.
+    iDestruct (big_sepM_insert _ _ r_t11 with "[$Hregs $Hr_t11]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     rewrite insert_commute;auto. rewrite insert_insert.
     (* move r_t8 0 *)
     destruct ai_rest'' as [| ? ai_rest'']; [by inversion Hlength_rest'''|].
     iPrologue "Hprog".
     rewrite !(insert_commute _ _ r_t8);auto.
-    iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[apply lookup_insert|]. 
+    iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[apply lookup_insert|].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_t8]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end'' a_end|iContiguous_next Hcont_rest''' 4|..].
     iEpilogue "(HPC & Hi & Hr_t8)". iCombine "Hi" "Hprog_done" as "Hprog_done".
-    iDestruct (big_sepM_insert _ _ r_t8 with "[$Hregs $Hr_t8]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert]. 
+    iDestruct (big_sepM_insert _ _ r_t8 with "[$Hregs $Hr_t8]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert].
     (* move r_t9 0 *)
     destruct ai_rest'' as [| ? ai_rest'']; [by inversion Hlength_rest'''|].
     iPrologue "Hprog".
     rewrite !(insert_commute _ _ r_t9);auto.
-    iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t8 Hregs]";[apply lookup_insert|]. 
+    iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t8 Hregs]";[apply lookup_insert|].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_t8]");
       [eapply decode_encode_instrW_inv|iCorrectPC a_crtcls_end'' a_end|iContiguous_next Hcont_rest''' 5|..].
     iEpilogue "(HPC & Hi & Hr_t9)". iCombine "Hi" "Hprog_done" as "Hprog_done".
-    iDestruct (big_sepM_insert _ _ r_t9 with "[$Hregs $Hr_t9]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert]. 
-    
+    iDestruct (big_sepM_insert _ _ r_t9 with "[$Hregs $Hr_t9]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert insert_insert].
+
 
     (* WE WILL NOW PREPARE THΕ JUMP *)
     iCombine "Hbe_cls'" "Hbe_cls''" as "Hbe_cls'".
@@ -738,7 +738,7 @@ Section counter_example_preamble.
     iAssert (interp (WCap E b_cls e_cls b_cls))%I as "#Hvalid_cls".
     { iApply (incr_closure_valid with "Hcounter_inv Hincr Hcls_inv");auto.
       apply Hvpc_counter. apply Hcont_restc. }
-    
+
     iAssert (interp (WCap E b_cls' e_cls' b_cls'))%I as "#Hvalid_cls'".
     { iApply (read_closure_valid with "Hcounter_inv Hread Hcls_inv Henv Hinv_assert");auto.
       apply Hcont_incr. apply Hvpc_counter. apply Hcont_reset. solve_ndisj. }
@@ -746,7 +746,7 @@ Section counter_example_preamble.
     iAssert (interp (WCap E b_cls'' e_cls'' b_cls''))%I as "#Hvalid_cls''".
     { iApply (reset_closure_valid with "Hcounter_inv Hreset Hcls_inv");auto.
       apply Hcont_incr. apply Hcont_read. apply Hvpc_counter. apply Hcont_reset. }
-    
+
     unshelve iPoseProof ("Hr_valid" $! r_t0 _ _ Hr0) as "#Hr0_valid". done.
 
     (* use the continuation in rt0 *)
@@ -754,7 +754,7 @@ Section counter_example_preamble.
 
     (* prepare the continuation *)
     iEpilogue "(HPC & Hi & Hr0)". iCombine "Hi" "Hprog_done" as "Hprog_done".
-    
+
     (* Put the registers back in the map *)
     iDestruct (big_sepM_insert with "[$Hregs $Hr2]") as "Hregs".
     { repeat (rewrite lookup_insert_ne //;[]). rewrite lookup_delete //. }

--- a/theories/examples/dynamic_sealing.v
+++ b/theories/examples/dynamic_sealing.v
@@ -283,7 +283,7 @@ Section sealing.
 
     codefrag_facts "Hprog".
     focus_block_0 "Hprog" as "Hprog" "Hcont".
-    assert (is_Some (rmap !! r_t7)) as [w7 Hw7];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t7)) as [w7 Hw7];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t7 with "Hregs") as "[Hr_t7 Hregs]";[apply Hw7|].
     iGo "Hprog".
     unfocus_block "Hprog" "Hcont" as "Hprog".
@@ -392,7 +392,7 @@ Section sealing.
     iIntros (Hvpc Hcont Hdom Hbounds Hf_m Hnclose') "(HPC & Hr_t0 & Hregs & Hown & Hprog & #Hmalloc & Hpc_b & Ha_r' & Hφ)".
 
     focus_block 2 "Hprog" as a_middle Ha_middle "Hprog" "Hcont".
-    assert (is_Some (rmap !! r_t8)) as [w8 Hw8];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t8)) as [w8 Hw8];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[apply Hw8|].
     iGo "Hprog".
     { rewrite /seal_instrs_length. instantiate (1 := (a_first ^+ length (unseal_instrs))%a).
@@ -415,7 +415,7 @@ Section sealing.
     focus_block 4 "Hprog" as a_middle2 Ha_middle2 "Hprog" "Hcont".
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[simplify_map_eq; auto|].
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]";[simplify_map_eq; auto|].
-    assert (is_Some (rmap !! r_t9)) as [w9 Hw9];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t9)) as [w9 Hw9];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t9 Hregs]";[simplify_map_eq; auto|].
     map_simpl "Hregs".
     iGo "Hprog".
@@ -438,7 +438,7 @@ Section sealing.
     focus_block 6 "Hprog" as a_middle4 Ha_middle4 "Hprog" "Hcont".
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[simplify_map_eq; auto|].
     iDestruct (big_sepM_delete _ _ r_t9 with "Hregs") as "[Hr_t9 Hregs]";[simplify_map_eq; auto|].
-    assert (is_Some (rmap !! r_t10)) as [w10 Hw10];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t10)) as [w10 Hw10];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t10 with "Hregs") as "[Hr_t10 Hregs]";[simplify_map_eq; auto|].
     map_simpl "Hregs".
     iGo "Hprog". instantiate (1 := a_first). rewrite /unseal_instrs_length. solve_addr.

--- a/theories/examples/interval.v
+++ b/theories/examples/interval.v
@@ -265,8 +265,8 @@ Section interval.
     set rmap2 := <[r_t2:=WInt 0%Z]> (<[r_t3:=WInt 0%Z]> (<[r_t4:=WInt 0%Z]>
                                 (<[r_t5:=WInt 0%Z]> (<[r_t6:=WInt 0%Z]> (<[r_t7:=WInt 0%Z]>
                                 (<[r_t8:=WInt 0%Z]> (<[r_t20:=WInt 0%Z]> rmap))))))).
-    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[apply elem_of_gmap_dom;rewrite Hdom;set_solver-|].
-    assert (is_Some (rmap !! r_t7)) as [w7 Hw7];[apply elem_of_gmap_dom;rewrite Hdom;set_solver-|].
+    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[apply elem_of_dom;rewrite Hdom;set_solver-|].
+    assert (is_Some (rmap !! r_t7)) as [w7 Hw7];[apply elem_of_dom;rewrite Hdom;set_solver-|].
     iDestruct (big_sepM_delete _ _ r_t6 with "Hregs") as "[Hr_t6 Hregs]";[eauto|].
     iDestruct (big_sepM_delete _ _ r_t7 with "Hregs") as "[Hr_t7 Hregs]";[simplify_map_eq;eauto|].
     (* open the program and seal env invariants *)
@@ -349,7 +349,7 @@ Section interval.
     assert (withinBounds ib ie ib = true) as Hwbi;[solve_addr+Hi Hibounds|].
     assert (withinBounds ib ie f = true) as Hwbi2;[solve_addr+Hi Hibounds|].
     (* get the general purpose register to remember r_t0 *)
-    assert (is_Some (rmap !! r_t8)) as [w8 Hw8];[apply elem_of_gmap_dom;rewrite Hdom;set_solver-|].
+    assert (is_Some (rmap !! r_t8)) as [w8 Hw8];[apply elem_of_dom;rewrite Hdom;set_solver-|].
     iDestruct (big_sepM_delete _ _ r_t8 with "Hregs") as "[Hr_t8 Hregs]";[simplify_map_eq;eauto|].
 
     destruct (z1 <? z2)%Z eqn:Hz;iSimpl in "Hr_t2".
@@ -365,7 +365,7 @@ Section interval.
       (* unfocus_block "Hblock" "Hcont" as "Hcode". *)
 
       (* activation code *)
-      assert (is_Some (rmap !! r_t20)) as [w20 Hw20];[apply elem_of_gmap_dom;rewrite Hdom;set_solver-|].
+      assert (is_Some (rmap !! r_t20)) as [w20 Hw20];[apply elem_of_dom;rewrite Hdom;set_solver-|].
       iDestruct (big_sepM_delete _ _ r_t20 with "Hregs") as "[Hr_t20 Hregs]";[simplify_map_eq;eauto|].
       iApply closure_activation_spec; iFrameAutoSolve. iFrame "Hseal".
       iNext. iIntros "(HPC & Hr_t20 & Hr_env & Hseal)".
@@ -434,7 +434,7 @@ Section interval.
       (* unfocus_block "Hblock" "Hcont" as "Hcode". *)
 
       (* activation code *)
-      assert (is_Some (rmap !! r_t20)) as [w20 Hw20];[apply elem_of_gmap_dom;rewrite Hdom;set_solver-|].
+      assert (is_Some (rmap !! r_t20)) as [w20 Hw20];[apply elem_of_dom;rewrite Hdom;set_solver-|].
       iDestruct (big_sepM_delete _ _ r_t20 with "Hregs") as "[Hr_t20 Hregs]";[simplify_map_eq;eauto|].
       iApply closure_activation_spec; iFrameAutoSolve. iFrame "Hseal".
       iNext. iIntros "(HPC & Hr_t20 & Hr_env & Hseal)".
@@ -557,8 +557,8 @@ Section interval.
             "(HPC & Hr_t0 & Hr_env & Hr_t20 & Hregs & #Hseal_env & #HsealLL & Hown
             & #Hretval & #Hmalloc & #Htable & #Hprog & #Hregs_val) Hφ".
 
-    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
-    assert (is_Some (rmap !! r_t2)) as [w2 Hw2];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t2)) as [w2 Hw2];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]";[by simplify_map_eq|].
     iDestruct "Hr_t20" as (w20) "Hr_t20".
@@ -802,15 +802,15 @@ Section interval.
     iIntros (Hexec Hsub Hdom Hdisj Hdisj2 Hsidj3 φ) "(HPC & Hr_t0 & Hr_env & Hr_t20 & Hregs & #Hseal_env & #HsealLL & Hown & #Hretval & #Hprog & #Hregs_val) Hφ".
 
     (* extract the registers used by the program *)
-    assert (is_Some (rmap !! r_t5)) as [w5 Hw5];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t5)) as [w5 Hw5];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]";[eauto|].
-    assert (is_Some (rmap !! r_t2)) as [w2 Hw2];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t2)) as [w2 Hw2];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
-    assert (is_Some (rmap !! r_t3)) as [w3 Hw3];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t3)) as [w3 Hw3];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
-    assert (is_Some (rmap !! r_t4)) as [w4 Hw4];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t4)) as [w4 Hw4];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t4 with "Hregs") as "[Hr_t4 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
-    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
     iDestruct "Hr_t20" as (w20) "Hr_t20".
 
@@ -1047,15 +1047,15 @@ Section interval.
     iIntros (Hexec Hsub Hdom Hdisj Hdisj2 Hsidj3 φ) "(HPC & Hr_t0 & Hr_env & Hr_t20 & Hregs & #Hseal_env & #HsealLL & Hown & #Hretval & #Hprog & #Hregs_val) Hφ".
 
     (* extract the registers used by the program *)
-    assert (is_Some (rmap !! r_t5)) as [w5 Hw5];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t5)) as [w5 Hw5];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]";[eauto|].
-    assert (is_Some (rmap !! r_t2)) as [w2 Hw2];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t2)) as [w2 Hw2];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
-    assert (is_Some (rmap !! r_t3)) as [w3 Hw3];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t3)) as [w3 Hw3];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
-    assert (is_Some (rmap !! r_t4)) as [w4 Hw4];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t4)) as [w4 Hw4];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t4 with "Hregs") as "[Hr_t4 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
-    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]";[rewrite !lookup_delete_ne//;eauto|].
     iDestruct "Hr_t20" as (w20) "Hr_t20".
 

--- a/theories/examples/interval_arch.v
+++ b/theories/examples/interval_arch.v
@@ -693,7 +693,7 @@ Section interval.
 
     (* extract the registers used by the program *)
     (* We need this value later; create an equality for it now *)
-    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iExtractList "Hregs" [r_t5;r_t2;r_t1] as ["Hr_t5";"Hr_t2";"Hr_t3";"Hr_t4";"Hr_t1"].
     iDestruct "Hr_t20" as (w20) "Hr_t20".
 
@@ -893,7 +893,7 @@ Section interval.
 
     (* extract the registers used by the program *)
     (* We need this value later; create an equality for it now *)
-    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_gmap_dom;rewrite Hdom;set_solver|].
+    assert (is_Some (rmap !! r_t1)) as [w1 Hw1];[apply elem_of_dom;rewrite Hdom;set_solver|].
     iExtractList "Hregs" [r_t5;r_t2;r_t1] as ["Hr_t5";"Hr_t2";"Hr_t3";"Hr_t4";"Hr_t1"].
     iDestruct "Hr_t20" as (w20) "Hr_t20".
 

--- a/theories/examples/interval_client.v
+++ b/theories/examples/interval_client.v
@@ -185,11 +185,11 @@ Section interval_client.
     destruct Hcond as (He1 & He2 & He3).
     destruct Hi_pc as (Hvpci & Hboundsi).
 
-    assert (is_Some (rmap !! r_temp1)) as [w0 Hr_temp1];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
-    assert (is_Some (rmap !! r_temp2)) as [w1 Hr_temp2];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
-    assert (is_Some (rmap !! r_temp3)) as [w2 Hr_temp3];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
-    assert (is_Some (rmap !! r_temp4)) as [w3 Hr_temp4];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
-    assert (is_Some (rmap !! r_t2)) as [w4 Hr_t2];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp1)) as [w0 Hr_temp1];[apply elem_of_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp2)) as [w1 Hr_temp2];[apply elem_of_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp3)) as [w2 Hr_temp3];[apply elem_of_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp4)) as [w3 Hr_temp4];[apply elem_of_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_t2)) as [w4 Hr_t2];[apply elem_of_dom;rewrite Hdom;set_solver+|].
     iDestruct (big_sepM_delete _ _ r_temp1 with "Hregs") as "[Hr_temp1 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_temp2 with "Hregs") as "[Hr_temp2 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_temp3 with "Hregs") as "[Hr_temp3 Hregs]";[by simplify_map_eq|].
@@ -210,9 +210,9 @@ Section interval_client.
     iMod ("Hcls'" with "[$Hown Hact1 Hact2 Hact3 Hd1 Hd2 Hd3]") as "Hown".
     { iNext. iExists _,_. iFrame "Hact1 Hact2 Hact3". iFrame. auto. }
     iMod ("Hcls" with "[$Hown $Hcode]") as "Hown".
-    assert (is_Some (rmap !! r_t3)) as [w6 Hr_t3];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
-    assert (is_Some (rmap !! r_t4)) as [w7 Hr_t4];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
-    assert (is_Some (rmap !! r_t5)) as [w8 Hr_t5];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_t3)) as [w6 Hr_t3];[apply elem_of_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_t4)) as [w7 Hr_t4];[apply elem_of_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_t5)) as [w8 Hr_t5];[apply elem_of_dom;rewrite Hdom;set_solver+|].
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_t4 with "Hregs") as "[Hr_t4 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]";[by simplify_map_eq|].

--- a/theories/examples/interval_client_adequacy.v
+++ b/theories/examples/interval_client_adequacy.v
@@ -327,7 +327,7 @@ Proof.
       | _ : mkregion ?X1 ?X2 ?X3 !! _ = _ |- _ => set l := mkregion X1 X2 X3
       end.
       assert (is_Some (l !! assert_flag))
-        as Hdom%elem_of_gmap_dom;eauto.
+        as Hdom%elem_of_dom;eauto.
       apply in_dom_mkregion in Hdom.
       pose proof (regions_disjoint) as Hdisjoint.
       rewrite !disjoint_list_cons in Hdisjoint. destruct Hdisjoint as (?&?&?&?&?&?&?&?&?).
@@ -663,7 +663,7 @@ Section int_client_adequacy.
     rewrite -(insert_insert _ PC _ (WInt 0)).
     iDestruct ("Hcont" with "[$Hown $Hrmap]") as "Hcont".
     { rewrite /interp_reg /=. iSplit.
-      iPureIntro. intros. simpl. apply elem_of_gmap_dom. rewrite !dom_insert_L Hdom.
+      iPureIntro. intros. simpl. apply elem_of_dom. rewrite !dom_insert_L Hdom.
       pose proof (all_registers_s_correct x1) as Hx1. set_solver +Hx1.
       iIntros (r v Hrv). rewrite lookup_insert_ne//.
       destruct (decide (r_t0 = r));[subst;rewrite lookup_insert|rewrite lookup_insert_ne//].

--- a/theories/examples/interval_client_adequacy_arch.v
+++ b/theories/examples/interval_client_adequacy_arch.v
@@ -366,7 +366,7 @@ Proof.
       | _ : mkregion ?X1 ?X2 ?X3 !! _ = _ |- _ => set l := mkregion X1 X2 X3
       end.
       assert (is_Some (l !! assert_flag))
-        as Hdom%elem_of_gmap_dom;eauto.
+        as Hdom%elem_of_dom;eauto.
       apply in_dom_mkregion in Hdom.
       pose proof (regions_disjoint) as Hdisjoint.
       rewrite !disjoint_list_cons in Hdisjoint. destruct Hdisjoint as (?&?&?&?&?&?&?&?&?).
@@ -799,7 +799,7 @@ Section int_client_adequacy.
     rewrite -(insert_insert _ PC _ (WInt 0)).
     iDestruct ("Hcont" with "[$Hown $Hrmap]") as "Hcont".
     { rewrite /interp_reg /=. iSplit.
-      iPureIntro. intros. simpl. apply elem_of_gmap_dom. rewrite !dom_insert_L Hdom.
+      iPureIntro. intros. simpl. apply elem_of_dom. rewrite !dom_insert_L Hdom.
       pose proof (all_registers_s_correct x1) as Hx1. set_solver +Hx1.
       iIntros (r v Hrv). rewrite lookup_insert_ne//.
       destruct (decide (r_t0 = r));[subst;rewrite lookup_insert|rewrite lookup_insert_ne//].

--- a/theories/examples/interval_closure.v
+++ b/theories/examples/interval_closure.v
@@ -236,7 +236,7 @@ Section interval_closure.
     unfocus_block "Hblock" "Hcont" as "Hcode".
 
     (* get some general purpose registers *)
-    assert (is_Some (rmap !! r_temp1)) as [w Hr_temp1];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp1)) as [w Hr_temp1];[apply elem_of_dom;rewrite Hdom;set_solver+|].
     iDestruct (big_sepM_delete _ _ r_temp1 with "Hregs") as "[Hr_temp1 Hregs]".
     { rewrite !lookup_insert_ne// lookup_delete_ne//. }
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]";[by simplify_map_eq|].
@@ -254,7 +254,7 @@ Section interval_closure.
     unfocus_block "Hblock" "Hcont" as "Hcode".
 
     (* prepare to jump to makeseal *)
-    assert (is_Some (rmap !! r_temp6)) as [w0 Hr_temp6];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp6)) as [w0 Hr_temp6];[apply elem_of_dom;rewrite Hdom;set_solver+|].
     iDestruct (big_sepM_delete _ _ r_temp6 with "Hregs") as "[Hr_temp6 Hregs]".
     { rewrite !lookup_delete_ne// !lookup_insert_ne// lookup_delete_ne//. }
     focus_block 3 "Hcode" as a_mid2 Ha_mid2 "Hblock" "Hcont".
@@ -296,7 +296,7 @@ Section interval_closure.
     (* get some registers *)
     rewrite !(insert_commute _ _ r_temp1)// !(delete_insert_ne _ _ r_temp1)//
             !(insert_commute _ _ r_temp1)//.
-    assert (is_Some (rmap !! r_temp2)) as [w1 Hr_temp2];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp2)) as [w1 Hr_temp2];[apply elem_of_dom;rewrite Hdom;set_solver+|].
     iDestruct (big_sepM_delete _ _ r_temp2 with "Hregs") as "[Hr_temp2 Hregs]".
     { rewrite !lookup_insert_ne// !lookup_delete_ne// !lookup_insert_ne//. }
     rewrite delete_insert_ne//.
@@ -338,7 +338,7 @@ Section interval_closure.
 
     focus_block 5 "Hcode" as a_mid4 Ha_mid4 "Hblock" "Hcont".
     iDestruct (big_sepM_delete _ _ r_temp1 with "Hregs") as "[Hr_temp1 Hregs]";[by simplify_map_eq|].
-    assert (is_Some (rmap !! r_temp3)) as [w3 Hr_temp3];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp3)) as [w3 Hr_temp3];[apply elem_of_dom;rewrite Hdom;set_solver+|].
     iDestruct (big_sepM_delete _ _ r_temp3 with "Hregs") as "[Hr_temp3 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_temp2 with "Hregs") as "[Hr_temp2 Hregs]";[by simplify_map_eq|].
 
@@ -364,7 +364,7 @@ Section interval_closure.
     clear dependent a_mid0 a_mid3 a_mid4.
 
     focus_block 7 "Hcode" as a_mid6 Ha_mid6 "Hblock" "Hcont".
-    assert (is_Some (rmap !! r_temp4)) as [w4 Hr_temp4];[apply elem_of_gmap_dom;rewrite Hdom;set_solver+|].
+    assert (is_Some (rmap !! r_temp4)) as [w4 Hr_temp4];[apply elem_of_dom;rewrite Hdom;set_solver+|].
     iDestruct (big_sepM_delete _ _ r_temp4 with "Hregs") as "[Hr_temp4 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_temp1 with "Hregs") as "[Hr_temp1 Hregs]";[by simplify_map_eq|].
     iDestruct (big_sepM_delete _ _ r_temp2 with "Hregs") as "[Hr_temp2 Hregs]";[by simplify_map_eq|].

--- a/theories/examples/keylist.v
+++ b/theories/examples/keylist.v
@@ -676,7 +676,7 @@ Section list.
     iDestruct "HisList" as (hd) "[Hll HisList]". iDestruct "HisList" as (pbvals') "(>HisList & >Hexact & HΦ)".
     iDestruct (big_sepL2_length with "Hprog") as %Hprog_length.
     (* extract some registers *)
-    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[rewrite elem_of_gmap_dom Hdom; set_solver|].
+    assert (is_Some (rmap !! r_t6)) as [w6 Hw6];[rewrite -elem_of_dom Hdom; set_solver|].
     iDestruct (big_sepM_delete _ _ r_t6 with "Hregs") as "[Hr_t6 Hregs]";[apply Hw6|].
 
     focus_block_0 "Hprog" as "Hprog" "Hcont".
@@ -686,9 +686,9 @@ Section list.
     focus_block 1 "Hprog" as a_middle Ha_middle "Hprog" "Hcont".
     iDestruct (big_sepM_insert _ _ r_t6 with "[$Hregs $Hr_t6]") as "Hregs";[apply lookup_delete|rewrite insert_delete_insert].
     iDestruct (big_sepM_insert _ _ r_env with "[$Hregs $Hr_env]") as "Hregs".
-    { rewrite !lookup_insert_ne//. rewrite elem_of_gmap_dom_none Hdom. set_solver. }
+    { rewrite !lookup_insert_ne//. rewrite -not_elem_of_dom Hdom. set_solver. }
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hregs $Hr_t1]") as "Hregs".
-    { rewrite !lookup_insert_ne//. rewrite elem_of_gmap_dom_none Hdom. set_solver. }
+    { rewrite !lookup_insert_ne//. rewrite -not_elem_of_dom Hdom. set_solver. }
     iApply malloc_spec; iFrameAutoSolve. 4: iFrame "∗ #". rewrite !dom_insert_L Hdom. clear. set_solver by lia.
     solve_ndisj. lia.
     iNext. iIntros "(HPC & Hmalloc_prog & Hpc_b & Ha_r' & Hreg & Hr_t0 & Hown & Hregs)".
@@ -705,7 +705,7 @@ Section list.
     destruct l;[inversion Hlen_eq|].
     destruct l;[inversion Hlen_eq|]. destruct l;[|inversion Hlen_eq].
     iDestruct "Hbe'" as "[Hbnew [ Ha [Ha' _] ] ]".
-    rewrite delete_insert. 2: rewrite !lookup_insert_ne// elem_of_gmap_dom_none Hdom;set_solver.
+    rewrite delete_insert. 2: rewrite !lookup_insert_ne// -not_elem_of_dom Hdom;set_solver.
     repeat (rewrite -(insert_commute _ r_env)//).
     iDestruct (big_sepM_delete _ _ r_env with "Hregs") as "[Hr_env Hregs]";[apply lookup_insert|].
     rewrite !(insert_commute _ _ r_t6)// !(delete_insert_ne _ _ r_t6)//.

--- a/theories/examples/lse.v
+++ b/theories/examples/lse.v
@@ -95,11 +95,11 @@ Section roe.
             "(HPC & Hr_adv & Hregs & Hown & Hprog & #Hwadv & #Hmalloc & #Hassert & Hpc_b & Ha_entry & Ha_entry' & #Hflag) Hφ".
     (* extract r_t0 *)
     assert (is_Some (rmap !! r_t0)) as [w0 Hw0].
-    { apply elem_of_gmap_dom. rewrite Hdom. clear;set_solver. }
+    { apply elem_of_dom. rewrite Hdom. clear;set_solver. }
     iDestruct (big_sepM_delete with "Hregs") as "[Hr_t0 Hregs]";[apply Hw0|].
     (* put back r_adv *)
     iDestruct (big_sepM_insert with "[$Hregs $Hr_adv]") as "Hregs".
-    { rewrite lookup_delete_ne;auto. apply elem_of_gmap_dom_none. rewrite Hdom. clear;set_solver. }
+    { rewrite lookup_delete_ne;auto. apply not_elem_of_dom. rewrite Hdom. clear;set_solver. }
 
     (* prepare the program addresses for malloc *)
     iDestruct (contiguous_between_program_split with "Hprog") as
@@ -124,11 +124,11 @@ Section roe.
 
     (* extract r_env and r_t7 *)
     assert (is_Some (rmap !! r_env)) as [wenv Hwenv].
-    { apply elem_of_gmap_dom. rewrite Hdom. clear;set_solver. }
+    { apply elem_of_dom. rewrite Hdom. clear;set_solver. }
     iDestruct (big_sepM_delete _ _ r_env with "Hregs") as "[Hr_env Hregs]";[rewrite !lookup_insert_ne// lookup_delete_ne//
                                                                                     !lookup_insert_ne// lookup_delete_ne//|].
     assert (is_Some (rmap !! r_t7)) as [w7 Hw7].
-    { apply elem_of_gmap_dom. rewrite Hdom. clear;set_solver. }
+    { apply elem_of_dom. rewrite Hdom. clear;set_solver. }
     iDestruct (big_sepM_delete _ _ r_t7 with "Hregs") as "[Hr_t7 Hregs]";[rewrite lookup_delete_ne// !lookup_insert_ne// lookup_delete_ne//
                                                                                     !lookup_insert_ne// lookup_delete_ne//|].
     (* continue *)
@@ -185,7 +185,7 @@ Section roe.
     iDestruct (big_sepM_delete _ _ r_adv with "Hregs") as "[Hr_adv Hregs]";[rewrite !lookup_delete_ne// !lookup_insert_ne//
                                                                                     lookup_delete_ne//; apply lookup_insert|].
     rewrite (delete_insert_ne _ _ r_adv)// !(insert_commute _ _ r_adv)// (delete_insert_ne _ _ r_adv)// (delete_insert_ne _ _ r_adv)// delete_insert.
-    2: { rewrite !lookup_delete_ne// !lookup_insert_ne// !lookup_delete_ne//. apply elem_of_gmap_dom_none. rewrite Hdom. clear; set_solver. }
+    2: { rewrite !lookup_delete_ne// !lookup_insert_ne// !lookup_delete_ne//. apply not_elem_of_dom. rewrite Hdom. clear; set_solver. }
     iDestruct (big_sepM_insert with "[$Hregs $Hr_t1]") as "Hregs";[rewrite !lookup_delete_ne// !lookup_insert_ne//; apply lookup_delete|].
     rewrite - !(delete_insert_ne _ r_t1)// 2!(delete_commute _ _ r_t1)// insert_delete_insert.
     (* apply the call spec *)
@@ -230,11 +230,11 @@ Section roe.
     (* Let's assert that the continuation holds *)
     iDestruct (big_sepM_to_create_gmap_default _ _ (λ k i, k ↦ᵣ i)%I (WInt 0%Z) with "Hregs")  as "Hregs";[apply Permutation_refl|reflexivity|].
     iDestruct (big_sepM_insert with "[$Hregs $Hr_adv]") as "Hregs".
-    { apply elem_of_gmap_dom_none. rewrite create_gmap_default_dom list_to_set_map_to_list !dom_delete_L Hdom. clear. set_solver. }
+    { apply not_elem_of_dom. rewrite create_gmap_default_dom list_to_set_map_to_list !dom_delete_L Hdom. clear. set_solver. }
     iDestruct (big_sepM_insert with "[$Hregs $Hr_t7]") as "Hregs".
-    { apply elem_of_gmap_dom_none. rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list !dom_delete_L Hdom. clear. set_solver. }
+    { apply not_elem_of_dom. rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list !dom_delete_L Hdom. clear. set_solver. }
     iDestruct (big_sepM_insert with "[$Hregs $Hr_t0]") as "Hregs".
-    { apply elem_of_gmap_dom_none. rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list !dom_delete_L Hdom. clear. set_solver. }
+    { apply not_elem_of_dom. rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list !dom_delete_L Hdom. clear. set_solver. }
 
     match goal with |- context [ ([∗ map] k↦y ∈ ?regs, k ↦ᵣ y)%I ] =>
           set rmap2 := regs

--- a/theories/examples/lse_adequacy.v
+++ b/theories/examples/lse_adequacy.v
@@ -265,7 +265,7 @@ Section roe_adequacy.
     iSplit.
     - rewrite /minv_sep /=. iIntros "HH". iDestruct "HH" as (m) "(Hm & %Heq & %HOK)".
       assert (is_Some (m !! l_assert_flag)) as [? Hlook].
-      { apply elem_of_gmap_dom. rewrite Heq. apply elem_of_singleton. auto. }
+      { apply elem_of_dom. rewrite Heq. apply elem_of_singleton. auto. }
       iDestruct (big_sepM_lookup _ _ l_assert_flag with "Hm") as "Hflag";eauto.
       apply HOK in Hlook as ->. iFrame.
     - iIntros "HH". iExists {[ l_assert_flag := WInt 0%Z ]}.

--- a/theories/examples/macros.v
+++ b/theories/examples/macros.v
@@ -347,13 +347,13 @@ Section macros.
             "(>Hprog & #Hmalloc & Hna & >Hpc_b & >Ha_entry & >HPC & >Hr_t0 & >Hregs & Hφ)".
     (* extract necessary registers from regs *)
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
-    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]"; eauto.
-    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]". by rewrite lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]". by rewrite !lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]". by rewrite !lookup_delete_ne //.
     destruct a as [|a l];[inversion Hlength|].
     apply contiguous_between_cons_inv_first in Hcont as Heq. subst.
@@ -516,13 +516,13 @@ Section macros.
             "(>Hprog & #Hmalloc & Hna & >Hpc_b & >Ha_entry & >HPC & >Hr_t0 & >Hregs & Hψ & Hφfailed & Hφ)".
     (* extract necessary registers from regs *)
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
-    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]"; eauto.
-    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]". by rewrite lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]". by rewrite !lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]". by rewrite !lookup_delete_ne //.
     destruct a as [|a l];[inversion Hlength|].
     apply contiguous_between_cons_inv_first in Hcont as Heq. subst.
@@ -682,7 +682,7 @@ Section macros.
     iDestruct (big_sepL2_cons with "Hrclear") as "[Ha1 Hrclear]".
     rewrite list_to_set_cons in Hrdom.
     assert (is_Some (rmap !! r)) as [rv ?].
-    { rewrite elem_of_gmap_dom -Hrdom. set_solver. }
+    { rewrite -elem_of_dom -Hrdom. set_solver. }
     iDestruct (big_sepM_delete _ _ r with "Hreg") as "[Hr Hreg]". eauto.
     pose proof (contiguous_between_cons_inv _ _ _ _ Ha) as [-> [a2 [? Hcont'] ] ].
     iApply (wp_move_success_z with "[$HPC $Hr $Ha1]");
@@ -1815,9 +1815,9 @@ Section macros.
             "(>Hprog & >HPC & #Hmalloc & Hna & >Hpc_b & >Ha_entry & >Hr_t0 & >Hr_t1 & >Hr_t2 & >Hregs & Hφ)".
     (* get some registers out of regs *)
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
-    assert (is_Some (rmap !! r_t6)) as [rv6 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t6)) as [rv6 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t6 with "Hregs") as "[Hr_t6 Hregs]"; eauto.
-    assert (is_Some (rmap !! r_t7)) as [rv7 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t7)) as [rv7 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t7 with "Hregs") as "[Hr_t7 Hregs]". by rewrite lookup_delete_ne //.
     destruct a as [|a l];[inversion Hlength|].
     apply contiguous_between_cons_inv_first in Hcont as Heq. subst.

--- a/theories/examples/macros_binary.v
+++ b/theories/examples/macros_binary.v
@@ -3,11 +3,11 @@ From iris.proofmode Require Import proofmode.
 Require Import Eqdep_dec List.
 From cap_machine Require Import rules rules_binary logrel macros_helpers.
 From cap_machine Require Export iris_extra addr_reg_sample contiguous malloc_binary.
-From cap_machine Require Import macros. 
+From cap_machine Require Import macros.
 
-(** This file contains specification side specs for macros. Malloc, and the first 
-    part of crtclosure is written out as a binary specification, since malloc must 
-    happen in lock step 
+(** This file contains specification side specs for macros. Malloc, and the first
+    part of crtclosure is written out as a binary specification, since malloc must
+    happen in lock step
  *)
 
 Ltac iPrologue_s prog :=
@@ -23,7 +23,7 @@ Section macros.
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
 
-  
+
   (* --------------------------------------------------------------------------------- *)
   (* ------------------------------------- FETCH ------------------------------------- *)
   (* --------------------------------------------------------------------------------- *)
@@ -53,7 +53,7 @@ Section macros.
           ∗ r_t1 ↣ᵣ wentry ∗ r_t2 ↣ᵣ WInt 0%Z ∗ r_t3 ↣ᵣ WInt 0%Z
           ∗ pc_b ↣ₐ WCap RO b_link e_link a_link
           ∗ entry_a ↣ₐ wentry.
-    
+
   Proof.
     iIntros (Hvpc Hcont Hwb Hentry Hnclose) "(>Hprog & #Hspec & Hj & >HPC & >Hpc_b & >Ha_entry & >Hr_t1 & >Hr_t2 & >Hr_t3)".
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
@@ -67,39 +67,39 @@ Section macros.
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont 0|auto|..].
     iEpilogue_s.
     (* getb r_t2 r_t1 *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
     iMod (step_Get_success _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t1 $Hr_t2]")
       as "(Hj & HPC & Hi & Hr_t1 & Hr_t2)";
       [apply decode_encode_instrW_inv|auto|iCorrectPC a_first a_last|iContiguous_next Hcont 1|auto..].
-    iEpilogue_s. iCombine "Hi" "Hprog_done" as "Hprog_done". 
+    iEpilogue_s. iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* geta r_t3 r_t1 *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
     iMod (step_Get_success _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t1 $Hr_t3]")
       as "(Hj & HPC & Hi & Hr_t1 & Hr_t3)";
       [apply decode_encode_instrW_inv|auto|iCorrectPC a_first a_last|iContiguous_next Hcont 2|auto..].
-    iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done". 
+    iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* sub r_t2 r_t2 r_t3 *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
     iMod (step_add_sub_lt_success_dst_r _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t3 $Hr_t2]")
       as "(Hj & HPC & Hi & Hr_t3 & Hr_t2)";
       [apply decode_encode_instrW_inv|auto|iContiguous_next Hcont 3|iCorrectPC a_first a_last|auto..].
-    iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done". 
+    iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* lea r_t1 r_t2 *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
-    assert ((a_first + (pc_b - a_first))%a = Some pc_b) as Hlea;[solve_addr|]. 
+    assert ((a_first + (pc_b - a_first))%a = Some pc_b) as Hlea;[solve_addr|].
     iMod (step_lea_success_reg _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t1 $Hr_t2]")
       as "(Hj & HPC & Hi & Hr_t2 & Hr_t1) /=";
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont 4|apply Hlea|auto..].
     { apply contiguous_between_length in Hcont.
       apply isCorrectPC_range_perm in Hvpc; [|revert Hcont; clear; solve_addr].
       destruct Hvpc as [-> | ->]; auto. }
-    iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done". 
+    iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* load r_t1 r_t1 *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
     iMod (step_load_success_same_alt _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t1 Hpc_b]")
       as "(Hj & HPC & Hr_t1 & Hi & Hpc_b)";
@@ -109,27 +109,27 @@ Section macros.
       assert (pc_b < pc_e)%Z as Hle.
       { eapply isCorrectPC_contiguous_range in Hvpc as Hwb';[|eauto|apply elem_of_cons;left;eauto].
         inversion Hwb'. solve_addr. }
-      apply isCorrectPC_range_perm in Hvpc as Heq; [|revert Hlen; clear; solve_addr].      
+      apply isCorrectPC_range_perm in Hvpc as Heq; [|revert Hlen; clear; solve_addr].
       split;[destruct Heq as [-> | ->]; auto|].
       apply andb_true_intro. split;[apply Z.leb_le;solve_addr|apply Z.ltb_lt;auto].
     }
     iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* lea r_t1 f *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
     iMod (step_lea_success_z _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t1]")
       as "(Hj & HPC & Hi & Hr_t1)";
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont 6|apply Hentry|simpl;auto..].
     iEpilogue_s ; iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* move r_t2 0 *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
     iMod (step_move_success_z _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t2]")
       as "(Hj & HPC & Hi & Hr_t2)";
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont 7|auto|..].
     iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* move r_t3 0 *)
-    destruct l;[inversion Hlength|]. 
+    destruct l;[inversion Hlength|].
     iPrologue_s "Hprog".
     iMod (step_move_success_z _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t3]")
       as "(Hj & HPC & Hi & Hr_t3)";
@@ -144,7 +144,7 @@ Section macros.
       [exact wentry|apply decode_encode_instrW_inv|iCorrectPC a_first a_last|auto|apply Hlink|auto..].
     iEpilogue_s; iCombine "Hi" "Hprog_done" as "Hprog_done".
     (* macro is done *)
-    iFrame. do 9 iDestruct "Hprog_done" as "[$ Hprog_done]". by iFrame. 
+    iFrame. do 9 iDestruct "Hprog_done" as "[$ Hprog_done]". by iFrame.
   Qed.
 
   (* --------------------------------------------------------------------------------- *)
@@ -152,8 +152,8 @@ Section macros.
   (* --------------------------------------------------------------------------------- *)
 
   Definition malloc_s f_m size a : iProp Σ :=
-    ([∗ list] a_i;w_i ∈ a;(malloc_instrs f_m size), a_i ↣ₐ w_i)%I. 
-   
+    ([∗ list] a_i;w_i ∈ a;(malloc_instrs f_m size), a_i ↣ₐ w_i)%I.
+
   (* malloc spec *)
   Lemma malloc_s_spec φ size cont cont'
         a pc_p pc_b pc_e a_first a_last
@@ -162,21 +162,21 @@ Section macros.
         bs_link es_link as_link fs_m as_entry
         mallocN b_m e_m EN
         rmap smap :
-    
+
     isCorrectPC_range pc_p pc_b pc_e a_first a_last →
     isCorrectPC_range pcs_p pcs_b pcs_e s_first s_last →
     contiguous_between a a_first a_last →
     contiguous_between a' s_first s_last →
-    
+
     withinBounds b_link e_link a_entry = true →
     (a_link + f_m)%a = Some a_entry →
 
     withinBounds bs_link es_link as_entry = true →
     (as_link + fs_m)%a = Some as_entry →
-    
+
     dom rmap = all_registers_s ∖ {[ PC; r_t0 ]} →
     dom smap = all_registers_s ∖ {[ PC; r_t0 ]} →
-    
+
     ↑mallocN ⊆ EN →
     nclose specN ⊆ EN →
     size > 0 →
@@ -219,31 +219,31 @@ Section macros.
       WP Seq (Instr Executable) {{ λ v, φ v ∨ ⌜v = FailedV⌝ }}.
   Proof.
     iIntros (Hvpc1 Hvpc2 Hcont1 Hcont2 Hwb1 Ha_entry Hwb2 Has_entry Hrmap_dom Hsmap_dom HmallocN HspecN Hsize)
-            "(>Hprog & >Hsprog & #Hspec & Hj & #Hmalloc & Hna 
-            & >Hpc_b & >Hpcs_b & >Ha_entry & >Hs_entry & >HPC & > HsPC 
-            & >Hr_t0 & >Hs_t0 & >Hregs & >Hsegs & Hφ)".      
+            "(>Hprog & >Hsprog & #Hspec & Hj & #Hmalloc & Hna
+            & >Hpc_b & >Hpcs_b & >Ha_entry & >Hs_entry & >HPC & > HsPC
+            & >Hr_t0 & >Hs_t0 & >Hregs & >Hsegs & Hφ)".
     (* extract necessary registers from regs *)
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
     iDestruct (big_sepL2_length with "Hsprog") as %Hslength.
-    
-    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+
+    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]"; eauto.
-    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]". by rewrite lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]". by rewrite !lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]". by rewrite !lookup_delete_ne //.
-    
-    assert (is_Some (smap !! r_t1)) as [sv1 ?]. by rewrite elem_of_gmap_dom Hsmap_dom; set_solver.
+
+    assert (is_Some (smap !! r_t1)) as [sv1 ?]. by rewrite -elem_of_dom Hsmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t1 with "Hsegs") as "[Hs_t1 Hsegs]"; eauto.
-    assert (is_Some (smap !! r_t2)) as [sv2 ?]. by rewrite elem_of_gmap_dom Hsmap_dom; set_solver.
+    assert (is_Some (smap !! r_t2)) as [sv2 ?]. by rewrite -elem_of_dom Hsmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t2 with "Hsegs") as "[Hs_t2 Hsegs]". by rewrite lookup_delete_ne //.
-    assert (is_Some (smap !! r_t3)) as [sv3 ?]. by rewrite elem_of_gmap_dom Hsmap_dom; set_solver.
+    assert (is_Some (smap !! r_t3)) as [sv3 ?]. by rewrite -elem_of_dom Hsmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hsegs") as "[Hs_t3 Hsegs]". by rewrite !lookup_delete_ne //.
-    assert (is_Some (smap !! r_t5)) as [sv5 ?]. by rewrite elem_of_gmap_dom Hsmap_dom; set_solver.
+    assert (is_Some (smap !! r_t5)) as [sv5 ?]. by rewrite -elem_of_dom Hsmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t5 with "Hsegs") as "[Hs_t5 Hsegs]". by rewrite !lookup_delete_ne //.
-    
+
     destruct a as [|a l];[inversion Hlength|].
     apply contiguous_between_cons_inv_first in Hcont1 as Heq. subst.
     destruct a' as [|a' ls];[inversion Hslength|].
@@ -253,7 +253,7 @@ Section macros.
                                                                    "(Hfetch & Hprog & #Hcont)";[apply Hcont1|].
     iDestruct "Hcont" as %(Hcont_fetch & Hcont_rest & Heqapp & Hlink).
     iApply (fetch_spec with "[- $HPC $Hfetch $Hr_t1 $Hr_t2 $Hr_t3 $Ha_entry $Hpc_b]");
-      [|apply Hcont_fetch|apply Hwb1|apply Ha_entry|]. 
+      [|apply Hcont_fetch|apply Hwb1|apply Ha_entry|].
     { intros mid Hmid. apply isCorrectPC_inrange with a_first a_last; auto.
       apply contiguous_between_bounds in Hcont_rest. revert Hcont_rest Hmid; clear. solve_addr. }
     iNext. iIntros "(HPC & Hfetch& Hr_t1 & Hr_t2 & Hr_t3 & Hpc_b & Ha_entry)".
@@ -268,7 +268,7 @@ Section macros.
     iDestruct "Hcont" as %(Hcont_fetchs & Hcont_rests & Heqapps & Hlinks).
     iMod (fetch_s_spec with "[$Hspec $Hj $HsPC $Hfetchs $Hs_t1 $Hs_t2 $Hs_t3 $Hs_entry $Hpcs_b]")
       as "(Hj & HsPC & Hfetchs & Hs_t1 & Hs_t2 & Hs_t3 & Hpcs_b & Hs_entry)";
-      [|apply Hcont_fetchs|apply Hwb2|apply Has_entry|auto..]. 
+      [|apply Hcont_fetchs|apply Hwb2|apply Has_entry|auto..].
     { intros mid Hmid. apply isCorrectPC_inrange with s_first s_last; auto.
       apply contiguous_between_bounds in Hcont_rests. revert Hcont_rests Hmid; clear. solve_addr. }
     iDestruct (big_sepL2_length with "Hsprog") as %Hlength_rests.
@@ -277,7 +277,7 @@ Section macros.
     destruct rests as [|a ls'];[inversion Hlength_rests|].
     apply contiguous_between_cons_inv_first in Hcont_rests as Heq. subst.
     (* move r_t5 r_t0 *)
-    destruct l';[inversion Hlength_rest|]. destruct ls';[inversion Hlength_rests|]. 
+    destruct l';[inversion Hlength_rest|]. destruct ls';[inversion Hlength_rests|].
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_move_success_reg _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t5 $Hs_t0]")
       as "(Hj & HsPC & Hsprog_done & Hs_t5 & Hs_t0)";
@@ -288,7 +288,7 @@ Section macros.
     iCombine "Hprog_done" "Hfetch" as "Hprog_done".
     iCombine "Hsprog_done" "Hfetchs" as "Hsprog_done".
     (* move r_t3 r_t1 *)
-    destruct l';[inversion Hlength_rest|]. destruct ls';[inversion Hlength_rests|]. 
+    destruct l';[inversion Hlength_rest|]. destruct ls';[inversion Hlength_rests|].
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_move_success_reg _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t3 $Hs_t1]")
       as "(Hj & HsPC & Hsi & Hs_t3 & Hs_t1)";
@@ -304,7 +304,7 @@ Section macros.
       [apply decode_encode_instrW_inv|iCorrectPC links s_last|iContiguous_next Hcont_rests 2|auto|..].
     iApply (wp_move_success_z with "[$HPC $Hi $Hr_t1]");
       [apply decode_encode_instrW_inv|iCorrectPC link a_last|iContiguous_next Hcont_rest 2|auto|..].
-    iEpilogue_both "(HPC & Hi & Hr_t1)"; iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t1)"; iCombinePtrn.
     (* move r_t0 PC *)
     destruct l';[inversion Hlength_rest|]. destruct ls';[inversion Hlength_rests|].
     iPrologue_both "Hprog" "Hsprog".
@@ -313,7 +313,7 @@ Section macros.
       [apply decode_encode_instrW_inv|iCorrectPC links s_last|iContiguous_next Hcont_rests 3|auto|..].
     iApply (wp_move_success_reg_fromPC with "[$HPC $Hi $Hr_t0]");
       [apply decode_encode_instrW_inv|iCorrectPC link a_last|iContiguous_next Hcont_rest 3|auto|..].
-    iEpilogue_both "(HPC & Hi & Hr_t0)"; iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t0)"; iCombinePtrn.
     (* lea r_t0 3 *)
     destruct l';[inversion Hlength_rest|]. destruct l';[inversion Hlength_rest|].
     destruct ls';[inversion Hlength_rests|]. destruct ls';[inversion Hlength_rests|].
@@ -333,16 +333,16 @@ Section macros.
     { apply contiguous_between_length in Hcont1.
       apply isCorrectPC_range_perm in Hvpc1; [|revert Hcont1; clear; solve_addr].
       destruct Hvpc1 as [-> | -> ]; auto. }
-    iEpilogue_both "(HPC & Hi & Hr_t0)"; iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t0)"; iCombinePtrn.
     (* jmp r_t3 *)
     destruct l';[inversion Hlength_rest|]. destruct ls';[inversion Hlength_rests|].
     iPrologue_both "Hprog" "Hsprog".
     iMod (step_jmp_success _ [SeqCtx] with "[$Hspec $Hj $HsPC $Hsi $Hs_t3]")
       as "(Hj & HsPC & Hsi & Hs_t3)";
-      [apply decode_encode_instrW_inv|iCorrectPC links s_last|auto|]. 
+      [apply decode_encode_instrW_inv|iCorrectPC links s_last|auto|].
     iApply (wp_jmp_success with "[$HPC $Hi $Hr_t3]");
-      [apply decode_encode_instrW_inv|iCorrectPC link a_last|]. 
-    iEpilogue_both "(HPC & Hi & Hr_t3) /="; iCombinePtrn. 
+      [apply decode_encode_instrW_inv|iCorrectPC link a_last|].
+    iEpilogue_both "(HPC & Hi & Hr_t3) /="; iCombinePtrn.
     (* we are now ready to use the malloc subroutine spec. For this we prepare the registers *)
     iDestruct (big_sepM_insert _ _ r_t3 with "[$Hregs $Hr_t3]") as "Hregs";[by rewrite lookup_delete_ne // lookup_delete|].
     iDestruct (big_sepM_insert _ _ r_t3 with "[$Hsegs $Hs_t3]") as "Hsegs";[by rewrite lookup_delete_ne // lookup_delete|].
@@ -350,7 +350,7 @@ Section macros.
       by rewrite lookup_insert_ne // lookup_delete_ne // lookup_delete_ne // lookup_delete.
     iDestruct (big_sepM_insert _ _ r_t2 with "[$Hsegs $Hs_t2]") as "Hsegs".
       by rewrite lookup_insert_ne // lookup_delete_ne // lookup_delete_ne // lookup_delete.
-    
+
     rewrite - !(delete_insert_ne _ r_t5 r_t3) // !insert_delete_insert.
     rewrite - !(delete_insert_ne _ r_t5 r_t2) // !(insert_commute _ r_t2 r_t3) //.
     rewrite !insert_delete_insert.
@@ -359,7 +359,7 @@ Section macros.
       by rewrite lookup_delete.
     iDestruct (big_sepM_insert _ _ r_t5 with "[$Hsegs $Hs_t5]") as "Hsegs".
       by rewrite lookup_delete. rewrite !insert_delete_insert.
-      
+
     iApply (wp_wand with "[-]").
     iApply (malloc_binary.simple_malloc_subroutine_spec with "[- $Hspec $Hj $Hmalloc $Hna $Hregs $Hsegs $Hr_t0 $Hs_t0 $HPC $HsPC $Hr_t1 $Hs_t1]"); auto.
     { rewrite !dom_insert_L dom_delete_L Hrmap_dom.
@@ -380,7 +380,7 @@ Section macros.
          clear; solve_addr. }
 
     iIntros "(Hna & Hregs & Hr_t0 & HPC & Hsegs & Hs_t0 & HsPC & Hj & Hbe) /=".
-    iDestruct "Hbe" as (b e size' Hsize' Hbe) "(Hr_t1 & Hs_t1 & Hbe & Hsbe)". inversion Hsize'; subst size'. 
+    iDestruct "Hbe" as (b e size' Hsize' Hbe) "(Hr_t1 & Hs_t1 & Hbe & Hsbe)". inversion Hsize'; subst size'.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]".
       by rewrite lookup_insert_ne // lookup_insert //.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hsegs") as "[Hs_t3 Hsegs]".
@@ -416,27 +416,27 @@ Section macros.
     iEpilogue_both "(HPC & Hi & Hr_t5)"; iCombinePtrn.
     (* continuation *)
     iApply "Hφ".
-    iFrame "HsPC HPC Hj". iSplitL "Hprog_done".  
+    iFrame "HsPC HPC Hj". iSplitL "Hprog_done".
     { rewrite Heqapp. repeat (iDestruct "Hprog_done" as "[$ Hprog_done]"). iFrame. done. }
-    iSplitL "Hsprog_done".  
+    iSplitL "Hsprog_done".
     { rewrite Heqapps. repeat (iDestruct "Hsprog_done" as "[$ Hsprog_done]"). iFrame. done. }
     iFrame.
     iDestruct (big_sepM_insert _ _ r_t5 with "[$Hregs $Hr_t5]") as "Hregs".
     repeat (rewrite lookup_insert_ne //;[]). apply lookup_delete.
     iDestruct (big_sepM_insert _ _ r_t5 with "[$Hsegs $Hs_t5]") as "Hsegs".
     repeat (rewrite lookup_insert_ne //;[]). apply lookup_delete.
-    
+
     iDestruct (big_sepM_insert _ _ r_t3 with "[$Hregs $Hr_t3]") as "Hregs".
     repeat (rewrite lookup_insert_ne //;[]). rewrite lookup_delete_ne // lookup_delete //.
     iDestruct (big_sepM_insert _ _ r_t3 with "[$Hsegs $Hs_t3]") as "Hsegs".
     repeat (rewrite lookup_insert_ne //;[]). rewrite lookup_delete_ne // lookup_delete //.
-    
+
     repeat (rewrite (insert_commute _ r_t5) //;[]).
     rewrite !insert_delete_insert - !(delete_insert_ne _ _ r_t5) //.
     rewrite !(insert_commute _ r_t4 r_t2) // !insert_insert.
     repeat (rewrite -(delete_insert_ne _ r_t3);[|done]); rewrite insert_delete_insert.
-    repeat (rewrite -(delete_insert_ne _ r_t3);[|done]); rewrite insert_delete_insert. 
-    iFrame. 
+    repeat (rewrite -(delete_insert_ne _ r_t3);[|done]); rewrite insert_delete_insert.
+    iFrame.
     iExists b,e. iFrame. auto. auto.
   Qed.
 
@@ -463,7 +463,7 @@ Section macros.
      ={E}=∗ ⤇ Seq (Instr Executable)
          ∗ PC ↣ᵣ WCap p b e an
          ∗ ([∗ map] r_i↦_ ∈ rmap, r_i ↣ᵣ WInt 0%Z)
-         ∗ rclear_s a r.           
+         ∗ rclear_s a r.
   Proof.
     iIntros (Ha Hne Hhd Hvpc Hrdom Hnclose) "(#Hspec & Hj & >Hreg & >HPC & >Hrclear)".
     iDestruct (big_sepL2_length with "Hrclear") as %Har.
@@ -477,13 +477,13 @@ Section macros.
     iDestruct (big_sepL2_cons with "Hrclear") as "[Ha1 Hrclear]".
     rewrite list_to_set_cons in Hrdom.
     assert (is_Some (rmap !! r)) as [rv ?].
-    { rewrite elem_of_gmap_dom -Hrdom. set_solver. }
+    { rewrite -elem_of_dom -Hrdom. set_solver. }
     iDestruct (big_sepM_delete _ _ r with "Hreg") as "[Hr Hreg]". eauto.
     pose proof (contiguous_between_cons_inv _ _ _ _ Ha) as [-> [a2 [? Hcont'] ] ].
     iMod (step_move_success_z _ [SeqCtx] with "[$Hspec $Hj $HPC $Hr $Ha1]")
       as "(Hj & HPC & Ha1 & Hr)";
       [apply decode_encode_instrW_inv|iCorrectPC a1 an|eauto|auto..].
-    iEpilogue_s. 
+    iEpilogue_s.
     destruct a.
     { iFrame. inversion Hcont'; subst. iFrame.
       destruct r0; inversion Har. simpl in Hrdom.
@@ -491,14 +491,14 @@ Section macros.
       rewrite (_: delete r rmap = ∅). rewrite !big_sepM_empty. eauto.
       apply map_empty. intro. eapply (@not_elem_of_dom _ _ (gset RegName)).
       typeclasses eauto. rewrite dom_delete_L -Hrdom. set_solver. }
-    
+
     pose proof (contiguous_between_cons_inv_first _ _ _ _ Hcont') as ->.
     assert (PC ∉ r0). { apply not_elem_of_cons in Hne as [? ?]. auto. }
 
     destruct (decide (r ∈ r0)).
     { iDestruct (big_sepM_insert with "[$Hreg $Hr]") as "Hreg".
         by rewrite lookup_delete. rewrite insert_delete_insert.
-      (* iCombine "Ha1" "Hrclear" as "Hrclear". *) iSimpl. iFrame "Ha1". 
+      (* iCombine "Ha1" "Hrclear" as "Hrclear". *) iSimpl. iFrame "Ha1".
       iMod ("IH" with "Hj Hreg HPC Hrclear [] [] [] [] [] []") as "($&$&Hregs&$)";iFrame;eauto.
       { iPureIntro. intros ? [? ?]. apply Hvpc. solve_addr. }
       { iPureIntro. rewrite dom_insert_L -Hrdom. set_solver. }
@@ -508,11 +508,11 @@ Section macros.
     { iMod ("IH" with "Hj Hreg HPC Hrclear [] [] [] [] [] []") as "($&$&Hregs&$)";iFrame;eauto.
       { iPureIntro. intros ? [? ?]. apply Hvpc. solve_addr. }
       { iPureIntro. rewrite dom_delete_L -Hrdom. set_solver. }
-      iApply (big_sepM_delete _ _ r). eauto. iFrame. done. 
+      iApply (big_sepM_delete _ _ r). eauto. iFrame. done.
     }
   Qed.
 
-  
+
   (* --------------------------------------------------------------------------------- *)
   (* --------------------------------------- CRTCLS ---------------------------------- *)
   (* --------------------------------------------------------------------------------- *)
@@ -541,7 +541,7 @@ Section macros.
     (* memory for the activation record *)
     ∗ ▷ ([[act_b,act_e]] ↣ₐ [[ act ]])
     (* continuation *)
-    ={Ep}=∗ ⤇ Seq (Instr Executable) 
+    ={Ep}=∗ ⤇ Seq (Instr Executable)
         ∗ PC ↣ᵣ WCap pc_p pc_b pc_e a_last
         ∗ scrtcls_s rcode rdata a
         ∗ r_t1 ↣ᵣ WCap E act_b act_e act_b
@@ -599,7 +599,7 @@ Section macros.
     iEpilogue_s ; iCombine "Hi" "Hprog_done" as "Hprog_done"; iCombine "Ha1" "Hact'" as "Hact'".
     (* lea r_t1 1 *)
     destruct l;[inversion Hlength|].
-    destruct acta as [| ? acta];[inversion Hact_len_a|]. 
+    destruct acta as [| ? acta];[inversion Hact_len_a|].
     iPrologue_s "Hprog".
     iMod (step_lea_success_z _ [SeqCtx] with "[$Hspec $Hj $HPC $Hi $Hr_t1]")
       as "(Hj & HPC & Hi & Hr_t1)";
@@ -751,18 +751,18 @@ Section macros.
   Lemma crtcls_spec
         wvar wcode wvar' wcode' (* the environment and code capabilities can be different! *)
         a pc_p pc_b pc_e a_first a_last
-        a' pcs_p pcs_b pcs_e s_first s_last 
+        a' pcs_p pcs_b pcs_e s_first s_last
         f_m b_link a_link e_link a_entry
         fs_m bs_link as_link es_link as_entry
         b_m e_m mallocN EN
         rmap smap
         cont cont' φ :
-    
+
     isCorrectPC_range pc_p pc_b pc_e a_first a_last →
     isCorrectPC_range pcs_p pcs_b pcs_e s_first s_last →
     contiguous_between a a_first a_last →
     contiguous_between a' s_first s_last →
-    
+
     withinBounds b_link e_link a_entry = true →
     (a_link + f_m)%a = Some a_entry →
 
@@ -777,7 +777,7 @@ Section macros.
 
     spec_ctx
     ∗ ⤇ Seq (Instr Executable)
-    ∗ ▷ crtcls f_m a ∗ ▷ crtcls_s fs_m a' 
+    ∗ ▷ crtcls f_m a ∗ ▷ crtcls_s fs_m a'
     ∗ ▷ PC ↦ᵣ WCap pc_p pc_b pc_e a_first ∗ ▷ PC ↣ᵣ WCap pcs_p pcs_b pcs_e s_first
     ∗ na_inv logrel_nais mallocN (malloc_inv_binary b_m e_m)
     ∗ na_own logrel_nais EN
@@ -818,18 +818,18 @@ Section macros.
       WP Seq (Instr Executable) {{ λ v, φ v ∨ ⌜v = FailedV⌝ }}.
   Proof.
     iIntros (Hvpc1 Hvpc2 Hcont1 Hcont2 Hwb Ha_entry Hwb' Ha_entry' Hrmap_dom Hsmap_dom HmallocN HspecN)
-            "(#Hspec & Hj & >Hprog & >Hsprog & >HPC & >HsPC 
-            & #Hmalloc & Hna & >Hpc_b & >Hpcs_b & >Ha_entry & >Has_entry 
+            "(#Hspec & Hj & >Hprog & >Hsprog & >HPC & >HsPC
+            & #Hmalloc & Hna & >Hpc_b & >Hpcs_b & >Ha_entry & >Has_entry
             & >Hr_t0 & >Hs_t0 & >Hr_t1 & >Hs_t1 & >Hr_t2 & >Hs_t2 & >Hregs & >Hsegs & Hφ)".
     (* get some registers out of regs *)
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
     iDestruct (big_sepL2_length with "Hsprog") as %Hlengths.
-    assert (is_Some (rmap !! r_t6)) as [rv6 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
-    assert (is_Some (smap !! r_t6)) as [sv6 ?]. by rewrite elem_of_gmap_dom Hsmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t6)) as [rv6 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
+    assert (is_Some (smap !! r_t6)) as [sv6 ?]. by rewrite -elem_of_dom Hsmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t6 with "Hregs") as "[Hr_t6 Hregs]"; eauto.
     iDestruct (big_sepM_delete _ _ r_t6 with "Hsegs") as "[Hs_t6 Hsegs]"; eauto.
-    assert (is_Some (rmap !! r_t7)) as [rv7 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
-    assert (is_Some (smap !! r_t7)) as [sv7 ?]. by rewrite elem_of_gmap_dom Hsmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t7)) as [rv7 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
+    assert (is_Some (smap !! r_t7)) as [sv7 ?]. by rewrite -elem_of_dom Hsmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t7 with "Hregs") as "[Hr_t7 Hregs]". by rewrite lookup_delete_ne //.
     iDestruct (big_sepM_delete _ _ r_t7 with "Hsegs") as "[Hs_t7 Hsegs]". by rewrite lookup_delete_ne //.
 
@@ -854,7 +854,7 @@ Section macros.
       [apply decode_encode_instrW_inv|iCorrectPC s_first s_last|iContiguous_next Hcont2 1|auto|].
     iApply (wp_move_success_reg with "[$HPC $Hi $Hr_t7 $Hr_t2]");
       [apply decode_encode_instrW_inv|iCorrectPC a_first a_last|iContiguous_next Hcont1 1|].
-    iEpilogue_both "(HPC & Hi & Hr_t7 & Hr_t2)"; iCombinePtrn. 
+    iEpilogue_both "(HPC & Hi & Hr_t7 & Hr_t2)"; iCombinePtrn.
     assert (contiguous_between (f1 :: l) f1 a_last) as Hcont'.
     { apply contiguous_between_cons_inv in Hcont1 as [_ (? & ? & Hcont1)].
       apply contiguous_between_cons_inv in Hcont1 as [_ (? & ? & Hcont1)].
@@ -894,7 +894,7 @@ Section macros.
     iDestruct (big_sepM_insert with "[$Hregs $Hr_t1]") as "Hregs".
       by rewrite !lookup_insert_ne //; apply Hnotin_rmap; set_solver.
     iDestruct (big_sepM_insert with "[$Hsegs $Hs_t1]") as "Hsegs".
-      by rewrite !lookup_insert_ne //; apply Hnotin_smap; set_solver. 
+      by rewrite !lookup_insert_ne //; apply Hnotin_smap; set_solver.
     (* apply the malloc spec *)
     rewrite -/(malloc _ _ _).
     iApply (malloc_s_spec with "[- $Hspec $Hj $HPC $HsPC $Hmalloc $Hna $Hpc_b $Hpcs_b $Ha_entry $Has_entry
@@ -914,7 +914,7 @@ Section macros.
     { rewrite !dom_insert_L. rewrite Hsmap_dom.
       repeat (rewrite singleton_union_difference_L all_registers_union_l).
       f_equal. clear; set_solver. }
-    iNext. iIntros "(Hj & HPC & HsPC & Hmalloc_prog & Hmalloc_sprog & Hpc_b & Hpcs_b 
+    iNext. iIntros "(Hj & HPC & HsPC & Hmalloc_prog & Hmalloc_sprog & Hpc_b & Hpcs_b
     & Ha_entry & Has_entry & Hbe & Hr_t0 & Hs_t0 & Hna & Hregs & Hsegs)".
     iDestruct "Hbe" as (b e Hbe) "(Hr_t1 & Hs_t1 & Hbe & Hsbe)".
     rewrite !delete_insert_delete.
@@ -939,7 +939,7 @@ Section macros.
       apply contiguous_between_incr_addr with (i:=2) (ai:=f1) in Hcont1; auto.
       revert Hmid Hcont_rest Hcont_fetch Hcont1 ; clear. solve_addr. }
     iNext. iIntros "(HPC & Hscrtcls_prog & Hr_t1 & Hact & Hr_t6 & Hr_t7)".
-    
+
     iMod (scrtcls_s_spec with "[$Hspec $Hj $Hsprog $HsPC $Hs_t1 $Hs_t6 $Hs_t7 $Hsbe]")
       as "(Hj & HsPC & Hscrtcls_sprog & Hs_t1 & Hacts & Hs_t6 & Hs_t7)"; eauto.
     { intros mid Hmid. apply isCorrectPC_inrange with s_first s_last; auto.
@@ -947,7 +947,7 @@ Section macros.
       apply contiguous_between_bounds in Hcont_fetchs.
       apply contiguous_between_incr_addr with (i:=2) (ai:=f2) in Hcont2; auto.
       revert Hmid Hcont_rests Hcont_fetchs Hcont2 ; clear. solve_addr. }
-    
+
     (* continuation *)
     iApply "Hφ". iFrame "HPC HsPC Hpc_b Hpcs_b Ha_entry Has_entry Hj". iSplitL "Hprog_done Hmalloc_prog Hscrtcls_prog".
     { rewrite Heqapp. iDestruct "Hprog_done" as "[? ?]". iFrame. }
@@ -976,7 +976,7 @@ Section macros.
     rewrite (delete_notin _ r_t2). 2: rewrite !lookup_delete_ne //; apply Hnotin_smap; set_solver.
     repeat (repeat (rewrite -delete_insert_ne //; []); rewrite insert_delete_insert).
     repeat (rewrite (insert_commute _ r_t7) //;[]).
-    repeat (rewrite (insert_commute _ r_t6) //;[]). iFrame. 
+    repeat (rewrite (insert_commute _ r_t6) //;[]). iFrame.
   Qed.
 
   (* ------------------------------- Closure Activation --------------------------------- *)
@@ -986,7 +986,7 @@ Section macros.
     isCorrectPC_range pc_p b_cls e_cls b_cls e_cls →
     pc_p ≠ E →
     nclose specN ⊆ Ep →
-    
+
     spec_ctx
     ∗ ⤇ Seq (Instr Executable)
     ∗ PC ↣ᵣ WCap pc_p b_cls e_cls b_cls
@@ -1039,7 +1039,7 @@ Section macros.
        split;[done|] | iContiguous_next Hcont_cls 2 |auto ..].
     { eapply contiguous_between_middle_bounds' in Hcont_cls as [? ?].
       by eapply le_addr_withinBounds; eauto. repeat constructor. }
-    iEpilogue_s. 
+    iEpilogue_s.
     iCombine "Hi Hprog_done" as "Hprog_done".
     (* lea r_t1 (-1) *)
     iPrologue_s "Hprog".
@@ -1058,7 +1058,7 @@ Section macros.
        split;[done|] | iContiguous_next Hcont_cls 4 | auto..].
     { eapply contiguous_between_middle_bounds' in Hcont_cls as [? ?].
       by eapply le_addr_withinBounds; eauto. repeat constructor. }
-    iEpilogue_s. 
+    iEpilogue_s.
     iCombine "Hi Hprog_done" as "Hprog_done".
     (* jmp r_t1 *)
     iPrologue_s "Hprog".
@@ -1066,7 +1066,7 @@ Section macros.
       as "(Hj & HPC & Hi & Hr1)";
       [apply decode_encode_instrW_inv | iCorrectPC b_cls e_cls | auto.. ].
     iEpilogue_s.
-    iFrame. do 4 (iDestruct "Hprog_done" as "(? & Hprog_done)"). iFrame. done. 
+    iFrame. do 4 (iDestruct "Hprog_done" as "(? & Hprog_done)"). iFrame. done.
   Qed.
 
 

--- a/theories/examples/macros_helpers.v
+++ b/theories/examples/macros_helpers.v
@@ -116,7 +116,7 @@ Ltac iContiguous_next Ha index :=
 Ltac disjoint_from_rmap rmap :=
   match goal with
   | Hsub : _ ⊆ dom rmap |- _ !! ?r = _ =>
-    assert (is_Some (rmap !! r)) as [x Hx];[apply elem_of_gmap_dom;apply Hsub;constructor|];
+    assert (is_Some (rmap !! r)) as [x Hx];[apply elem_of_dom;apply Hsub;constructor|];
     apply map_disjoint_Some_l with rmap x;auto;apply map_disjoint_union_r_2;auto
   end.
 

--- a/theories/examples/macros_new.v
+++ b/theories/examples/macros_new.v
@@ -200,13 +200,13 @@ Section macros.
             "(>Hprog & #Hmalloc & Hna & >Hpc_b & >Ha_entry & >HPC & >Hr_t0 & >Hregs & Hψ & Hφfailed & Hφ)".
     (* extract necessary registers from regs *)
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
-    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]"; eauto.
-    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]". by rewrite lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]". by rewrite !lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]". by rewrite !lookup_delete_ne //.
 
     rewrite {1}/malloc_instrs.
@@ -371,13 +371,13 @@ Section macros.
             "(>Hprog & #Hsalloc & Hna & >Hpc_b & >Ha_entry & >HPC & >Hr_t0 & >Hregs & Hψ & Hφfailed & Hφ)".
     (* extract necessary registers from regs *)
     iDestruct (big_sepL2_length with "Hprog") as %Hlength.
-    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t1)) as [rv1 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[Hr_t1 Hregs]"; eauto.
-    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t2)) as [rv2 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t2 with "Hregs") as "[Hr_t2 Hregs]". by rewrite lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t3)) as [rv3 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hregs") as "[Hr_t3 Hregs]". by rewrite !lookup_delete_ne //.
-    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t5)) as [rv5 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t5 with "Hregs") as "[Hr_t5 Hregs]". by rewrite !lookup_delete_ne //.
 
     rewrite {1}/salloc_instrs.
@@ -703,7 +703,7 @@ Section macros.
 
     iIntros (? Hrdom). cbn [list_to_set] in Hrdom.
     assert (is_Some (rmap !! r0)) as [r0v Hr0].
-    { apply elem_of_gmap_dom. rewrite -Hrdom. set_solver. }
+    { apply elem_of_dom. rewrite -Hrdom. set_solver. }
     iDestruct (big_sepM_delete _ _ r0 with "Hreg") as "[Hr0 Hreg]". by eauto.
     codefrag_facts "Hrclear".
     iInstr "Hrclear". transitivity (Some (a_first ^+ 1)%a); auto. solve_addr.
@@ -924,9 +924,9 @@ Section macros.
     iIntros (Hvpc Hcont Hwb Ha_entry Hrmap_dom HmallocN)
             "(>Hprog & >HPC & #Hmalloc & Hna & >Hpc_b & >Ha_entry & >Hr_t0 & >Hr_t1 & >Hr_t2 & >Hregs & Hψ & Hφfailed & Hφ)".
     (* extract necessary registers from regs *)
-    assert (is_Some (rmap !! r_t6)) as [rv6 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t6)) as [rv6 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t6 with "Hregs") as "[Hr_t6 Hregs]"; eauto.
-    assert (is_Some (rmap !! r_t7)) as [rv7 ?]. by rewrite elem_of_gmap_dom Hrmap_dom; set_solver.
+    assert (is_Some (rmap !! r_t7)) as [rv7 ?]. by rewrite -elem_of_dom Hrmap_dom; set_solver.
     iDestruct (big_sepM_delete _ _ r_t7 with "Hregs") as "[Hr_t7 Hregs]". by rewrite lookup_delete_ne //.
 
     focus_block_0 "Hprog" as "Hsetup" "Hcont".

--- a/theories/examples/malloc.v
+++ b/theories/examples/malloc.v
@@ -95,11 +95,11 @@ Section SimpleMalloc.
     destruct Hbounds as [Hbm_am Ham_e].
     (* Get some registers *)
     assert (is_Some (rmap !! r_t2)) as [r2w Hr2w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     assert (is_Some (rmap !! r_t3)) as [r3w Hr3w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     assert (is_Some (rmap !! r_t4)) as [r4w Hr4w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     iDestruct (big_sepM_delete _ _ r_t2 with "Hrmap") as "[Hr2 Hrmap]".
       eassumption.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hrmap") as "[Hr3 Hrmap]".
@@ -219,7 +219,7 @@ Section SimpleMalloc.
     destruct H with r_t1 as [? ?].
     iDestruct (big_sepM_delete _ _ r_t1 with "Hregs") as "[r_t1 Hregs]";[rewrite !lookup_delete_ne// !lookup_insert_ne//;eauto|].
     iApply (wp_wand with "[-]").
-    iApply (simple_malloc_subroutine_spec with "[- $Hown $Hmalloc $Hregs $r_t0 $HPC $r_t1]");[|solve_ndisj|]. 
+    iApply (simple_malloc_subroutine_spec with "[- $Hown $Hmalloc $Hregs $r_t0 $HPC $r_t1]");[|solve_ndisj|].
     3: { iSimpl. iIntros (v) "[H | ->]". iExact "H". iIntros (Hcontr); done. }
     { rewrite !dom_delete_L dom_insert_L. apply regmap_full_dom in H as <-. set_solver. }
     unshelve iDestruct ("Hregs_valid" $! r_t0 _ _ H0) as "Hr0_valid";auto.

--- a/theories/examples/malloc_binary.v
+++ b/theories/examples/malloc_binary.v
@@ -102,17 +102,17 @@ Section SimpleMalloc.
     iDestruct "Hbounds" as %[Hbm_am Ham_e].
     (* Get some registers *)
     assert (is_Some (rmap !! r_t2)) as [r2w Hr2w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     assert (is_Some (rmap !! r_t3)) as [r3w Hr3w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     assert (is_Some (rmap !! r_t4)) as [r4w Hr4w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     assert (is_Some (smap !! r_t2)) as [s2w Hs2w].
-    { rewrite elem_of_gmap_dom Hsmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hsmap_dom. set_solver. }
     assert (is_Some (smap !! r_t3)) as [s3w Hs3w].
-    { rewrite elem_of_gmap_dom Hsmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hsmap_dom. set_solver. }
     assert (is_Some (smap !! r_t4)) as [s4w Hs4w].
-    { rewrite elem_of_gmap_dom Hsmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hsmap_dom. set_solver. }
     iDestruct (big_sepM_delete _ _ r_t2 with "Hrmap") as "[Hr2 Hrmap]".
     eassumption.
     iDestruct (big_sepM_delete _ _ r_t2 with "Hsmap") as "[Hs2 Hsmap]".

--- a/theories/examples/minimal_counter.v
+++ b/theories/examples/minimal_counter.v
@@ -260,13 +260,13 @@ Section counter.
     { intros ? w ?. cbn. iIntros "[? %Hw]". iFrame. destruct w; try inversion Hw.
       iApply interp_int. }
     iDestruct (big_sepM_insert _ _ r_t2 with "[$Hrmap $Hr2]") as "Hrmap".
-      by rewrite elem_of_gmap_dom_none Hrdom; set_solver+.
+      by rewrite -not_elem_of_dom Hrdom; set_solver+.
       by iApply interp_int.
     iDestruct (big_sepM_insert _ _ r_t1 with "[$Hrmap $Hr1]") as "Hrmap".
-      by rewrite lookup_insert_ne // elem_of_gmap_dom_none Hrdom; set_solver+.
+      by rewrite lookup_insert_ne // -not_elem_of_dom Hrdom; set_solver+.
       by iApply "Hcode_safe".
     iDestruct (big_sepM_insert _ _ r_t0 with "[$Hrmap $Hr0]") as "Hrmap".
-      by rewrite !lookup_insert_ne // elem_of_gmap_dom_none Hrdom; set_solver+.
+      by rewrite !lookup_insert_ne // -not_elem_of_dom Hrdom; set_solver+.
       by iApply "Hadv".
 
     iApply (wp_wand with "[-]").
@@ -370,9 +370,9 @@ Proof.
   iDestruct "Hdat" as (wdat) "Hdat".
 
   assert (is_Some (rmap !! r_t1)) as [w1 Hr1].
-  { rewrite elem_of_gmap_dom Hrdom. set_solver+. }
+  { rewrite -elem_of_dom Hrdom. set_solver+. }
   assert (is_Some (rmap !! r_t2)) as [w2 Hr2].
-  { rewrite elem_of_gmap_dom Hrdom. set_solver+. }
+  { rewrite -elem_of_dom Hrdom. set_solver+. }
   iDestruct (big_sepM_delete _ _ r_t1 with "Hrmap") as "[[Hr1 _] Hrmap]"; eauto.
   iDestruct (big_sepM_delete _ _ r_t2 with "Hrmap") as "[[Hr2 _] Hrmap]".
     by rewrite lookup_delete_ne //.

--- a/theories/examples/salloc.v
+++ b/theories/examples/salloc.v
@@ -99,11 +99,11 @@ Section SimpleSalloc.
     destruct Hbounds as [Hbm_am Ham_e].
     (* Get some registers *)
     assert (is_Some (rmap !! r_t2)) as [r2w Hr2w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     assert (is_Some (rmap !! r_t3)) as [r3w Hr3w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     assert (is_Some (rmap !! r_t4)) as [r4w Hr4w].
-    { rewrite elem_of_gmap_dom Hrmap_dom. set_solver. }
+    { rewrite -elem_of_dom Hrmap_dom. set_solver. }
     iDestruct (big_sepM_delete _ _ r_t2 with "Hrmap") as "[Hr2 Hrmap]".
       eassumption.
     iDestruct (big_sepM_delete _ _ r_t3 with "Hrmap") as "[Hr3 Hrmap]".

--- a/theories/examples/template_adequacy.v
+++ b/theories/examples/template_adequacy.v
@@ -178,7 +178,7 @@ Section Adequacy.
       rewrite filter_dom_is_dom; auto. split; auto.
       eapply minv_sub_restrict; [ | | eapply HI]. rewrite filter_dom_is_dom//.
       transitivity (prog_region P); auto. rewrite /prog_in_inv.
-      eapply map_filter_sub; typeclasses eauto. }
+      eapply map_filter_subseteq; typeclasses eauto. }
 
     unfold is_initial_registers in Hreg.
     destruct Hreg as (HPC & Hrothers).
@@ -346,7 +346,7 @@ Section Adequacy.
       rewrite filter_dom_is_dom; auto. split; auto.
       eapply minv_sub_restrict; [ | | eapply HI]. rewrite filter_dom_is_dom//.
       transitivity (prog_region P); auto. rewrite /prog_in_inv.
-      eapply map_filter_sub; typeclasses eauto. }
+      eapply map_filter_subseteq; typeclasses eauto. }
 
     unfold is_initial_registers in Hreg.
     destruct Hreg as (HPC & Hr0 & Hne & Hrothers).
@@ -643,7 +643,7 @@ Section Adequacy.
       rewrite filter_dom_is_dom; auto. split; auto.
       eapply minv_sub_restrict; [ | | eapply HI]. rewrite filter_dom_is_dom//.
       transitivity (lib_region (priv_libs Lib)); auto. rewrite /prog_in_inv.
-      eapply map_filter_sub; typeclasses eauto.
+      eapply map_filter_subseteq; typeclasses eauto.
       transitivity (lib_region (pub_libs Lib ++ priv_libs Lib)); auto.
       rewrite lib_region_app. apply map_union_subseteq_r. auto.
     }

--- a/theories/examples/template_adequacy.v
+++ b/theories/examples/template_adequacy.v
@@ -49,7 +49,7 @@ Proof.
   eapply minv_dom_correct. 2: eassumption.
   intros a Ha.
   assert (is_Some (m !! a)) as [? ?].
-  { eapply elem_of_gmap_dom.
+  { eapply elem_of_dom.
     rewrite elem_of_subseteq in Hdom.
     eapply Hdom. auto. }
   eexists. split; eauto.
@@ -67,7 +67,7 @@ Proof.
   eapply minv_dom_correct. 2: eassumption.
   intros a Ha.
   assert (is_Some (m !! a)) as [? ?].
-  { eapply elem_of_gmap_dom.
+  { eapply elem_of_dom.
     rewrite elem_of_subseteq in Hdom.
     eapply Hdom. auto. }
   eexists. split; eauto.
@@ -83,7 +83,7 @@ Proof.
   rewrite (dom_filter_L _ _ d); auto.
   intros. split; intros H.
   { rewrite elem_of_subseteq in Hd. specialize (Hd _ H).
-    eapply elem_of_gmap_dom in Hd as [? ?]. eexists. split; eauto. }
+    eapply elem_of_dom in Hd as [? ?]. eexists. split; eauto. }
   { destruct H as [? [? ?] ]; auto. }
 Qed.
 
@@ -735,7 +735,7 @@ Theorem template_adequacy `{MachineParameters} (Σ : gFunctors)
 Proof.
   set (Σ' := #[invΣ; gen_heapΣ Addr Word; gen_heapΣ RegName Word;
               na_invΣ; sealStorePreΣ; Σ]).
-  intros. 
+  intros.
 eapply (@template_adequacy' Σ'); eauto; (* rewrite /invGpreS. solve_inG. *)
             typeclasses eauto.
 Qed.

--- a/theories/exercises/increment.v
+++ b/theories/exercises/increment.v
@@ -363,7 +363,7 @@ Section program_call.
       (b_act e_act b_local e_local a_end_call)
         "( %Hnext & HPC & Hrmap & Hr9 & Hpcb & Haentry & Hr30 & Hr0 & Hact & Hlocals & Hcall & Hna )".
 
-    
+
     (* Cleaning *)
     iMod ("Hcls'" with "[$Hna $Haentry $Hpcb]") as "Hna".
     iHide "Hact" as Hact.
@@ -381,20 +381,20 @@ Section program_call.
     iDestruct (big_sepM_to_create_gmap_default _ _ (λ k i, k ↦ᵣ i)%I (WInt 0%Z) with "Hrmap")  as "Hrmap";[apply Permutation_refl|reflexivity|].
     (* r0 *)
     iDestruct (big_sepM_insert with "[$Hrmap $Hr0]") as "Hrmap".
-    { apply elem_of_gmap_dom_none.
+    { apply not_elem_of_dom.
       rewrite create_gmap_default_dom list_to_set_map_to_list.
       rewrite !dom_insert_L Hdom.
       clear; set_solver.
     }
     (* r30 *)
     iDestruct (big_sepM_insert with "[$Hrmap $Hr30]") as "Hrmap".
-    { apply elem_of_gmap_dom_none.
+    { apply not_elem_of_dom.
       rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list.
       rewrite !dom_insert_L Hdom.
       clear; set_solver. }
     (* r7 *)
     iDestruct (big_sepM_insert with "[$Hrmap $Hr9]") as "Hrmap".
-    { apply elem_of_gmap_dom_none.
+    { apply not_elem_of_dom.
       rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list.
       rewrite !dom_insert_L Hdom.
       clear; set_solver. }

--- a/theories/exercises/subseg_buffer_call.v
+++ b/theories/exercises/subseg_buffer_call.v
@@ -298,21 +298,21 @@ Section program_call.
         ∗ pc_b ↦ₐ WCap RO b_link e_link a_link
         ∗ malloc_entry ↦ₐ WCap E b_m e_m b_m
         ∗ assert_entry ↦ₐ WCap E b_a e_a b_a
-                       
+
         ∗ na_own logrel_nais ⊤
         ∗ interp w0 ∗ interp wadv
 
        -∗ WP Seq (Instr Executable) {{λ v,
                (⌜v = HaltedV⌝ → ∃ r : Reg, full_map r ∧ registers_mapsto r ∗ na_own logrel_nais ⊤)%I
                ∨ ⌜v = FailedV⌝ }})%I.
-  
+
   Proof with (try solve_addr').
     iIntros
       (Hpc_perm Hpc_bounds Hcont Hwb_malloc Hwb_assert Hlink_malloc Hlink_assert Hsize Hdom)
       "(Hprog& #Hinv_malloc& #Hinv_assert& #Hinv_flag& HPC& Hr30& Hrmap&
 Hlink& Hentry_malloc& Hentry_assert& Hna& #Hw0& #Hadv)".
 
-    
+
     (* FTLR on wadv - we do it now because of the later modality *)
     iDestruct (jmp_to_unknown with "Hadv") as "Cont".
     iHide "Cont" as cont.
@@ -503,7 +503,7 @@ Hlink& Hentry_malloc& Hentry_assert& Hna& #Hw0& #Hadv)".
       replace (a_prog ^+ 11%nat)%a with a_call. done.
       rewrite Hlength_progi in Ha_call... }
     do 4 (rewrite delete_insert_ne ; eauto).
-    
+
     (* 2 - extract r2 and r3 *)
     iExtractList "Hrmap" [r_t2;r_t3] as ["Hr2";"Hr3"].
 
@@ -620,7 +620,7 @@ Hlink& Hentry_malloc& Hentry_assert& Hna& #Hw0& #Hadv)".
     (* r0 *)
     iDestruct (big_sepM_to_create_gmap_default _ _ (λ k i, k ↦ᵣ i)%I (WInt 0%Z) with "Hrmap")  as "Hrmap";[apply Permutation_refl|reflexivity|].
     iDestruct (big_sepM_insert with "[$Hrmap $Hr0]") as "Hrmap".
-    { apply elem_of_gmap_dom_none.
+    { apply not_elem_of_dom.
       rewrite create_gmap_default_dom list_to_set_map_to_list.
       rewrite !dom_delete_L
       ; rewrite !dom_insert_L
@@ -630,7 +630,7 @@ Hlink& Hentry_malloc& Hentry_assert& Hna& #Hw0& #Hadv)".
     }
     (* r30 *)
     iDestruct (big_sepM_insert with "[$Hrmap $Hr30]") as "Hrmap".
-    { apply elem_of_gmap_dom_none.
+    { apply not_elem_of_dom.
       rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list.
       rewrite !dom_delete_L
       ; rewrite !dom_insert_L
@@ -640,7 +640,7 @@ Hlink& Hentry_malloc& Hentry_assert& Hna& #Hw0& #Hadv)".
     (* r7 *)
     iDestruct (big_sepM_singleton (fun k a => k ↦ᵣ a)%I r_t7 _ with "Hr7") as "Hr7".
     iDestruct (big_sepM_insert with "[$Hrmap $Hr7]") as "Hrmap".
-    { apply elem_of_gmap_dom_none.
+    { apply not_elem_of_dom.
       rewrite !dom_insert_L create_gmap_default_dom list_to_set_map_to_list.
       rewrite !dom_delete_L
       ; rewrite !dom_insert_L
@@ -1152,7 +1152,7 @@ Section prog_call_correct.
       iSplit.
       - rewrite /minv_sep /=. iIntros "HH". iDestruct "HH" as (m) "(Hm & %Heq & %HOK)".
         assert (is_Some (m !! l_assert_flag)) as [? Hlook].
-        { apply elem_of_gmap_dom. rewrite Heq. apply elem_of_singleton. auto. }
+        { apply elem_of_dom. rewrite Heq. apply elem_of_singleton. auto. }
         iDestruct (big_sepM_lookup _ _ l_assert_flag with "Hm") as "Hflag";eauto.
         apply HOK in Hlook as ->. iFrame.
       - iIntros "HH". iExists {[ l_assert_flag := WInt 0%Z ]}.

--- a/theories/exercises/subseg_buffer_closure.v
+++ b/theories/exercises/subseg_buffer_closure.v
@@ -410,7 +410,7 @@ Section closure_program.
 
    (* 2 - prepare the registers for closure_full_run_spec *)
    apply regmap_full_dom in Hrfull.
-    assert (is_Some (regs !! r_t30)) as [w30 Hw30];[rewrite elem_of_gmap_dom Hrfull; set_solver|].
+    assert (is_Some (regs !! r_t30)) as [w30 Hw30];[rewrite -elem_of_dom Hrfull; set_solver|].
    iExtractList "Hregs" [PC;r_t30] as  ["HPC"; "Hw30"].
    iAssert (interp w30) as "Hw30i".
    { iApply ("Hrsafe" $! r_t30 w30) ; eauto.  }

--- a/theories/ftlr/AddSubLt.v
+++ b/theories/ftlr/AddSubLt.v
@@ -57,7 +57,7 @@ Section fundamental.
     iApply (wp_AddSubLt with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec; cycle 1.

--- a/theories/ftlr/Get.v
+++ b/theories/ftlr/Get.v
@@ -28,7 +28,7 @@ Section fundamental.
     iApply (wp_Get with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec; cycle 1.

--- a/theories/ftlr/IsPtr.v
+++ b/theories/ftlr/IsPtr.v
@@ -27,7 +27,7 @@ Section fundamental.
     iApply (wp_IsPtr with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec; cycle 1.

--- a/theories/ftlr/Jnz.v
+++ b/theories/ftlr/Jnz.v
@@ -27,7 +27,7 @@ Section fundamental.
     iApply (wp_Jnz with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec.

--- a/theories/ftlr/Lea.v
+++ b/theories/ftlr/Lea.v
@@ -26,7 +26,7 @@ Section fundamental.
     iApply (wp_lea with "[$Ha $Hmap]"); eauto.
     { by rewrite lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec as [ * Hdst ? Hz Hoffset HincrPC | * Hdst Hz Hoffset HincrPC | ].
@@ -36,7 +36,7 @@ Section fundamental.
       { destruct (decide (PC = dst)); simplify_map_eq; auto. }
 
       iApply wp_pure_step_later; auto.
-      iMod ("Hcls" with "[HP Ha]");[iExists w;iFrame|iModIntro]. 
+      iMod ("Hcls" with "[HP Ha]");[iExists w;iFrame|iModIntro].
       iNext.
       iIntros "_".
       iApply ("IH" $! regs' with "[%] [] [Hmap] [$Hown]").
@@ -87,7 +87,7 @@ Section fundamental.
       { destruct Hp; by subst p. }
       { by rewrite PermFlowsToReflexive. } }
     { iApply wp_pure_step_later; auto.
-      iMod ("Hcls" with "[HP Ha]");[iExists w;iFrame|iModIntro]. 
+      iMod ("Hcls" with "[HP Ha]");[iExists w;iFrame|iModIntro].
       iNext; iIntros "_".
       iApply wp_value; auto. iIntros; discriminate. }
   Qed.

--- a/theories/ftlr/Load.v
+++ b/theories/ftlr/Load.v
@@ -233,7 +233,7 @@ Section fundamental.
     iApply (wp_load with "[Hmap HLoadRest]");eauto.
     { by rewrite lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. rewrite lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. rewrite lookup_insert_is_Some'; eauto. }
     { iSplitR "Hmap"; auto. }
     iNext. iIntros (regs' retv). iDestruct 1 as (HSpec) "[Hmem Hmap]".
 

--- a/theories/ftlr/Mov.v
+++ b/theories/ftlr/Mov.v
@@ -27,7 +27,7 @@ Section fundamental.
     iApply (wp_Mov with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec; cycle 1.
@@ -82,7 +82,7 @@ Section fundamental.
             * repeat rewrite fixpoint_interp1_eq; auto.
             * destruct (reg_eq_dec PC r0).
               { subst r0.
-                - simplify_map_eq. 
+                - simplify_map_eq.
                   rewrite !fixpoint_interp1_eq /=.
                 destruct Hp as [Hp | Hp]; subst p''; try subst g'';
                   (iFrame "Hinv Hexec"). }

--- a/theories/ftlr/Restrict.v
+++ b/theories/ftlr/Restrict.v
@@ -9,7 +9,7 @@ Section fundamental.
   Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
-  
+
   Notation D := ((leibnizO Word) -n> iPropO Σ).
   Notation R := ((leibnizO Reg) -n> iPropO Σ).
   Implicit Types w : (leibnizO Word).
@@ -31,7 +31,7 @@ Section fundamental.
     intros HpnotE Hp. iIntros "#IH HA".
     iApply (interp_weakening with "IH HA"); eauto; try solve_addr.
   Qed.
-  
+
   Lemma match_perm_with_E_rewrite:
     forall (A: Type) p (a1 a2: A),
       match p with
@@ -54,7 +54,7 @@ Section fundamental.
     iApply (wp_Restrict with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec as [ * Hdst ? Hz Hfl HincrPC | * Hdst Hz Hfl HincrPC | ].

--- a/theories/ftlr/Seal.v
+++ b/theories/ftlr/Seal.v
@@ -46,7 +46,7 @@ Section fundamental.
     iApply (wp_Seal with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec as [ * Hr1 Hr2 Hseal Hwb HincrPC | ].

--- a/theories/ftlr/Store.v
+++ b/theories/ftlr/Store.v
@@ -36,9 +36,9 @@ Section fundamental.
 
   (* Description of what the resources are supposed to look like after opening the region if we need to, but before closing the region up again*)
   Definition allow_store_res r1 (regs : Reg) pc_a a p b e :=
-    (⌜read_reg_inr regs r1 p b e a⌝ ∗ 
+    (⌜read_reg_inr regs r1 p b e a⌝ ∗
       if decide (reg_allows_store regs r1 p b e a ∧ a ≠ pc_a) then
-          |={⊤ ∖ ↑logN.@pc_a,⊤ ∖ ↑logN.@pc_a ∖ ↑logN.@a}=> ∃ w, a ↦ₐ w ∗ region_open_resources a pc_a w 
+          |={⊤ ∖ ↑logN.@pc_a,⊤ ∖ ↑logN.@pc_a ∖ ↑logN.@a}=> ∃ w, a ↦ₐ w ∗ region_open_resources a pc_a w
     else True)%I.
 
   Definition allow_store_mem r1 (regs : Reg) pc_a pc_w (mem : gmap Addr Word) p b e a :=
@@ -46,7 +46,7 @@ Section fundamental.
     if decide (reg_allows_store regs r1 p b e a ∧ a ≠ pc_a) then
          ∃ w, ⌜mem = <[a:=w]> (<[pc_a:=pc_w]> ∅)⌝ ∗ region_open_resources a pc_a w
     else ⌜mem = <[pc_a:=pc_w]> ∅⌝)%I.
-  
+
 
   Lemma create_store_res:
     ∀ (r : leibnizO Reg) (p : Perm)
@@ -68,11 +68,11 @@ Section fundamental.
       iDestruct ("Hreg" $! r1 _ n Hrinr) as "Hvsrc".
       iAssert (inv (logN.@a0) ((interp_ref_inv a0) interp))%I as "#Hinva".
       { iApply (write_allowed_inv with "Hvsrc"); auto. }
-      iFrame "∗ #". 
+      iFrame "∗ #".
       iMod (inv_acc with "Hinva") as "[Hinv Hcls']";[solve_ndisj|].
-      iDestruct "Hinv" as (w) "[>Ha0 #Hinv]". 
+      iDestruct "Hinv" as (w) "[>Ha0 #Hinv]".
       iExists w. iFrame. done.
-    - done.  
+    - done.
   Qed.
 
 
@@ -91,25 +91,25 @@ Section fundamental.
     iDestruct "HStoreRes" as "(% & HStoreRes)".
 
     case_decide as Hallows.
-    - iMod "HStoreRes" as (w0) "[Ha0 HStoreRest]". 
-      iExists _. 
+    - iMod "HStoreRes" as (w0) "[Ha0 HStoreRest]".
+      iExists _.
       iSplitL "HStoreRest".
-      * iFrame "%". 
-        case_decide; last by exfalso.        
+      * iFrame "%".
+        case_decide; last by exfalso.
         iExists w0. iSplitR; auto.
       * iModIntro. iNext.
         destruct Hallows as ((Hrinr & Hra & Hwb) & Hne).
-        iApply memMap_resource_2ne; auto; iFrame. 
+        iApply memMap_resource_2ne; auto; iFrame.
     - iExists _.
-      iSplitR "Ha". 
+      iSplitR "Ha".
       + iFrame "%".
         case_decide; first by exfalso. auto.
       + iModIntro. iNext. by iApply memMap_resource_1.
   Qed.
 
-  
+
   Lemma mem_map_implies_pure_conds:
-    ∀ (r : leibnizO Reg) 
+    ∀ (r : leibnizO Reg)
       (a a0 : Addr) (w : Word) (r1 : RegName)
       (mem0 : gmap Addr Word) p b e,
         allow_store_mem r1 r a w mem0 p b e a0
@@ -123,7 +123,7 @@ Section fundamental.
       destruct Hallows' as ((Hrinr & Hra & Hwb) & Hne).
       iDestruct "HStoreRes" as (w0 ->) "HStoreRest".
       iSplitR. rewrite lookup_insert_ne; auto. by rewrite lookup_insert.
-      iExists p,b,e,a0. iSplit;auto. 
+      iExists p,b,e,a0. iSplit;auto.
       iPureIntro. case_decide;auto.
       exists w0. by simplify_map_eq.
     - iDestruct "HStoreRes" as "->".
@@ -133,7 +133,7 @@ Section fundamental.
       apply not_and_l in Hallows as [Hallows | Hallows]; try contradiction.
       assert (a0 = a) as ->.
       { apply finz_to_z_eq, Z.eq_dne. intros Hcontr. apply Hallows. by intros ->. }
-      simplify_map_eq. eauto. 
+      simplify_map_eq. eauto.
   Qed.
 
    Lemma mem_map_recover_res:
@@ -144,9 +144,9 @@ Section fundamental.
       → mem0 !! a0 = Some loadv
       → allow_store_mem src r a w mem0 p0 b0 e0 a0
         -∗ ([∗ map] a1↦w ∈ (<[a0:=storev]> mem0), a1 ↦ₐ w)
-        -∗ interp storev                
+        -∗ interp storev
         ={if decide (reg_allows_store r src p0 b0 e0 a0 ∧ a0 ≠ a) then ⊤ ∖ ↑logN.@a ∖ ↑logN.@a0 else ⊤ ∖ ↑logN.@a,⊤ ∖ ↑logN.@a}=∗
-            if decide (reg_allows_store r src p0 b0 e0 a0 ∧ a0 = a) then a ↦ₐ storev else a ↦ₐ w. 
+            if decide (reg_allows_store r src p0 b0 e0 a0 ∧ a0 = a) then a ↦ₐ storev else a ↦ₐ w.
   Proof.
     intros r a w src p0 b0 e0 a0 mem0 storev loadv Hrar Hloadv.
     iIntros "HLoadMem Hmem Hvalid".
@@ -155,15 +155,15 @@ Section fundamental.
     case_decide as Hdec. destruct Hdec as [Hallows Heq].
     -  destruct Hallows as [Hrinr [Hra Hwb] ].
        iDestruct "HLoadRes" as (w0) "[-> [Hval Hcls] ]".
-       simplify_map_eq. rewrite insert_insert. 
+       simplify_map_eq. rewrite insert_insert.
        rewrite memMap_resource_2ne; last auto. iDestruct "Hmem" as  "[Ha1 Haw]".
        iMod ("Hcls" with "[Ha1 Hvalid]") as "_";[iNext;iExists storev;iFrame|]. iModIntro.
-       rewrite decide_False; [done|]. apply not_and_r. right. auto. 
+       rewrite decide_False; [done|]. apply not_and_r. right. auto.
     - apply not_and_r in Hdec as [| <-%dec_stable].
       * by exfalso.
       * iDestruct "HLoadRes" as "->".
         rewrite insert_insert.
-        rewrite -memMap_resource_1. simplify_map_eq. by iFrame. 
+        rewrite -memMap_resource_1. simplify_map_eq. by iFrame.
   Qed.
 
   Lemma store_case (r : leibnizO Reg) (p : Perm) (b e a : Addr) (w : Word) (dst : RegName) (src : Z + RegName) P :
@@ -200,24 +200,24 @@ Section fundamental.
         destruct Hr0 as [wsrc Hsomer0].
         exists wsrc. by rewrite Hsomer0.
     }
-    
+
     (* Step 1: open the region, if necessary, and store all the resources obtained from the region in allow_load_res *)
     iDestruct (create_store_res with "Hreg") as "HStoreRes"; eauto.
 
-    
+
     (* Step2: derive the concrete map of memory we need, and any spatial predicates holding over it *)
     iMod (store_res_implies_mem_map with "HStoreRes Ha") as (mem) "[HStoreMem >HMemRes]".
-    
+
     (* Step 3:  derive the non-spatial conditions over the memory map*)
     iDestruct (mem_map_implies_pure_conds with "HStoreMem") as %(HReadPC & HStoreAP); auto.
 
     iApply (wp_store with "[Hmap HMemRes]"); eauto.
     { by rewrite lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. rewrite lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. rewrite lookup_insert_is_Some'; eauto. }
     { iSplitR "Hmap"; auto. }
     iNext. iIntros (regs' mem' retv). iDestruct 1 as (HSpec) "[Hmem Hmap]".
-    
+
     destruct HSpec as [* ? ? ? -> Hincr|* -> Hincr].
     { apply incrementPC_Some_inv in Hincr.
       destruct Hincr as (?&?&?&?&?&?&?&?).
@@ -234,30 +234,30 @@ Section fundamental.
         - simplify_map_eq. iSpecialize ("Hreg" $! _ _ n Hwoa).
            iFrame "Hreg".
       }
-      
+
       (* Step 4: return all the resources we had in order to close the second location in the region, in the cases where we need to *)
-      iMod (mem_map_recover_res with "HStoreMem Hmem Hvalidstore") as "Ha";[eauto|eauto|iModIntro]. 
+      iMod (mem_map_recover_res with "HStoreMem Hmem Hvalidstore") as "Ha";[eauto|eauto|iModIntro].
 
       iMod ("Hcls" with "[HP Ha]").
       { simplify_map_eq.
-        case_decide as Hwrite. 
+        case_decide as Hwrite.
         - case_decide.
           + iNext. iExists storev.
             iDestruct ("Hwrite" with "Hvalidstore") as "HPstore".
-            iFrame "∗ #". 
+            iFrame "∗ #".
           + iNext. iExists w. iFrame.
         - rewrite decide_False. iNext. iExists w. iFrame.
           intros [Hcontr ->].
           apply Hwrite. exists dst.
           destruct Hcontr as (Hlookup & Hwa & Hwb). simplify_map_eq.
-          apply andb_prop in Hwb. 
+          apply andb_prop in Hwb.
           revert Hwb. rewrite Z.leb_le Z.ltb_lt. intros. eexists _.
           split_and!; done.
       }
-      
+
       simplify_map_eq.
       rewrite insert_insert.
-      
+
       iModIntro; iNext; iIntros "_".
       iApply ("IH" with "[%] [] Hmap [$Hown]");auto.
       { rewrite !fixpoint_interp1_eq /=. destruct Hp as [-> | ->]; by iFrame "#". }
@@ -267,9 +267,9 @@ Section fundamental.
       - iDestruct "HStoreMem" as "(%&H)".
         iDestruct "H" as (w') "(->&[Hres Hcls'])". rewrite /region_open_resources.
         destruct a1. simplify_map_eq. rewrite memMap_resource_2ne; last auto.
-        iDestruct "Hmem" as "[Ha0 Ha]". 
+        iDestruct "Hmem" as "[Ha0 Ha]".
         iMod ("Hcls'" with "[Ha0 Hres]");[iExists w';iFrame|iModIntro].
-        iMod ("Hcls" with "[Ha HP]");[iExists w;iFrame|iModIntro]. 
+        iMod ("Hcls" with "[Ha HP]");[iExists w;iFrame|iModIntro].
         iApply wp_pure_step_later; auto.
         iNext; iIntros "_".
         iApply wp_value; auto. iIntros; discriminate.

--- a/theories/ftlr/Subseg.v
+++ b/theories/ftlr/Subseg.v
@@ -44,7 +44,7 @@ Section fundamental.
     iApply (interp_weakening with "IH Hinterp"); eauto.
     destruct p; reflexivity.
   Qed.
-  
+
   Lemma subseg_case (r : leibnizO Reg) (p : Perm)
         (b e a : Addr) (w : Word) (dst : RegName) (r1 r2 : Z + RegName) (P:D):
     ftlr_instr r p b e a w (Subseg dst r1 r2) P.
@@ -57,7 +57,7 @@ Section fundamental.
     iApply (wp_Subseg with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".

--- a/theories/ftlr/UnSeal.v
+++ b/theories/ftlr/UnSeal.v
@@ -47,7 +47,7 @@ Section fundamental.
     iApply (wp_UnSeal with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. }
 
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
     destruct HSpec as [ * Hr1 Hr2 Hunseal Hwb HincrPC | ].

--- a/theories/ftlr_binary/AddSubLt_binary.v
+++ b/theories/ftlr_binary/AddSubLt_binary.v
@@ -42,7 +42,7 @@ Section fundamental.
     iApply (wp_AddSubLt with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq. reflexivity. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -54,7 +54,7 @@ Section fundamental.
     iMod (step_AddSubLt _ [SeqCtx] i with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs' & Hs & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hs'" as %HSpec'.
@@ -94,5 +94,3 @@ Section fundamental.
   Qed.
 
 End fundamental.
-
-

--- a/theories/ftlr_binary/Get_binary.v
+++ b/theories/ftlr_binary/Get_binary.v
@@ -40,7 +40,7 @@ Section fundamental.
     iApply (wp_Get with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq. reflexivity. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -52,7 +52,7 @@ Section fundamental.
     iMod (step_Get _ [SeqCtx] with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs' & Hs & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hs" as %HSpec'.

--- a/theories/ftlr_binary/IsPtr_binary.v
+++ b/theories/ftlr_binary/IsPtr_binary.v
@@ -37,7 +37,7 @@ Section fundamental.
     iApply (wp_IsPtr with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq. reflexivity. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -49,7 +49,7 @@ Section fundamental.
     iMod (step_IsPtr _ [SeqCtx] with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs' & Hs & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hs" as %HSpec'.

--- a/theories/ftlr_binary/Jnz_binary.v
+++ b/theories/ftlr_binary/Jnz_binary.v
@@ -37,7 +37,7 @@ Section fundamental.
     iApply (wp_Jnz with "[$Ha $Hmap]"); eauto.
     { eapply lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -49,7 +49,7 @@ Section fundamental.
     iMod (step_Jnz _ [SeqCtx] with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs' & Hs & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hs'" as %HSpec'.

--- a/theories/ftlr_binary/Lea_binary.v
+++ b/theories/ftlr_binary/Lea_binary.v
@@ -48,7 +48,7 @@ Section fundamental.
     iApply (wp_lea with "[$Ha $Hmap]"); eauto.
     { eapply lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -60,7 +60,7 @@ Section fundamental.
     iMod (step_lea _ [SeqCtx] with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs' & Hs & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hs" as %HSpec'.
@@ -127,5 +127,3 @@ Section fundamental.
   Qed.
 
 End fundamental.
-
-

--- a/theories/ftlr_binary/Load_binary.v
+++ b/theories/ftlr_binary/Load_binary.v
@@ -260,7 +260,7 @@ Section fundamental.
     iApply (wp_load with "[Hmap HLoadRest]");eauto.
     { by rewrite lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. rewrite lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. rewrite lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     { iSplitR "Hmap"; auto. }
     iNext. iIntros (regs' retv). iDestruct 1 as (HSpec) "[Hmem Hmap]".
 
@@ -271,7 +271,7 @@ Section fundamental.
     iMod (step_Load _ [SeqCtx] with "[$HLoadRest' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs & #Hmovspec & Ha' & Hsmap) /=";eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { destruct (decide (reg_allows_load (<[PC:=WCap p b e a]> r1) src p0 b0 e0 a0 ∧ a0 ≠ a)); solve_ndisj. }
     iDestruct "Hmovspec" as %HSpec'.

--- a/theories/ftlr_binary/Mov_binary.v
+++ b/theories/ftlr_binary/Mov_binary.v
@@ -39,7 +39,7 @@ Section fundamental.
     iApply (wp_Mov with "[$Ha $Hmap]"); eauto.
     { simplify_map_eq; auto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr;eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr;eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -51,7 +51,7 @@ Section fundamental.
     iMod (step_Mov _ [SeqCtx] with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs & #Hmovspec & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hmovspec" as %HSpec'.

--- a/theories/ftlr_binary/Restrict_binary.v
+++ b/theories/ftlr_binary/Restrict_binary.v
@@ -49,7 +49,7 @@ Section fundamental.
     iApply (wp_Restrict with "[$Ha $Hmap]"); eauto.
     { eapply lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -61,7 +61,7 @@ Section fundamental.
     iMod (step_Restrict _ [SeqCtx] with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs' & Hs & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hs'" as %HSpec'.
@@ -126,4 +126,3 @@ Section fundamental.
   Qed.
 
 End fundamental.
-

--- a/theories/ftlr_binary/Seal_binary.v
+++ b/theories/ftlr_binary/Seal_binary.v
@@ -30,7 +30,7 @@ Section fundamental.
     iApply (wp_Seal with "[$Ha $Hmap]"); eauto.
     { eapply lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)

--- a/theories/ftlr_binary/Store_binary.v
+++ b/theories/ftlr_binary/Store_binary.v
@@ -246,7 +246,7 @@ Section fundamental.
     iApply (wp_store with "[Hmap HMemRes]"); eauto.
     { by rewrite lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. rewrite lookup_insert_is_Some'; eauto.
+      apply elem_of_dom. rewrite lookup_insert_is_Some'; eauto.
       right; destruct (Hsome rr); auto. }
     { iSplitR "Hmap"; auto. }
     iNext. iIntros (regs' mem' retv). iDestruct 1 as (HSpec) "[Hmem Hmap]".
@@ -258,7 +258,7 @@ Section fundamental.
     iMod (step_store _ [SeqCtx] with "[$HMemRes' $Hsmap $Hs $Hspec]") as (retv' regs'' mem'') "(Hs & Hs' & Hsmem & Hsmap) /=";eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { destruct (decide (reg_allows_store (<[PC:=WCap p b e a]> r1) dst p0 b0 e0 a0 ∧ a0 ≠ a)); solve_ndisj. }
     iDestruct "Hs" as %HSpec'.

--- a/theories/ftlr_binary/Subseg_binary.v
+++ b/theories/ftlr_binary/Subseg_binary.v
@@ -49,7 +49,7 @@ Section fundamental.
     iApply (wp_Subseg with "[$Ha $Hmap]"); eauto.
     { eapply lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)
@@ -61,7 +61,7 @@ Section fundamental.
     iMod (step_Subseg _ [SeqCtx] with "[$Ha' $Hsmap $Hs $Hspec]") as (retv' regs'') "(Hs' & Hs & Ha' & Hsmap) /=";[rewrite Heqw in Hi|..];eauto.
     { rewrite lookup_insert. eauto. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
+      apply elem_of_dom. destruct (decide (PC = rr));[subst;rewrite lookup_insert;eauto|rewrite lookup_insert_ne //].
       destruct Hsome with rr;eauto. }
     { solve_ndisj. }
     iDestruct "Hs'" as %HSpec'.
@@ -130,5 +130,3 @@ Section fundamental.
   Qed.
 
 End fundamental.
-
-

--- a/theories/ftlr_binary/UnSeal_binary.v
+++ b/theories/ftlr_binary/UnSeal_binary.v
@@ -30,7 +30,7 @@ Section fundamental.
     iApply (wp_UnSeal with "[$Ha $Hmap]"); eauto.
     { eapply lookup_insert. }
     { rewrite /subseteq /map_subseteq /set_subseteq_instance. intros rr _.
-      apply elem_of_gmap_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
+      apply elem_of_dom. apply lookup_insert_is_Some'; eauto. destruct Hsome with rr; eauto. }
     iIntros "!>" (regs' retv). iDestruct 1 as (HSpec) "[Ha Hmap]".
 
     (* we assert that w = w' *)

--- a/theories/fundamental.v
+++ b/theories/fundamental.v
@@ -19,8 +19,8 @@ Section fundamental.
     ⊢ (([∗ map] r0↦w ∈ r, r0 ↦ᵣ w) → ∃ w, reg ↦ᵣ w)%I.
   Proof.
     intros [w Hw].
-    iIntros "Hmap". iExists w. 
-    iApply (big_sepM_lookup (λ reg' i, reg' ↦ᵣ i)%I r reg w); eauto. 
+    iIntros "Hmap". iExists w.
+    iApply (big_sepM_lookup (λ reg' i, reg' ↦ᵣ i)%I r reg w); eauto.
   Qed.
 
   Lemma extract_r reg (r : RegName) w :
@@ -28,14 +28,14 @@ Section fundamental.
     ⊢ (([∗ map] r0↦w ∈ reg, r0 ↦ᵣ w) →
      (r ↦ᵣ w ∗ (∀ x', r ↦ᵣ x' -∗ [∗ map] k↦y ∈ <[r := x']> reg, k ↦ᵣ y)))%I.
   Proof.
-    iIntros (Hw) "Hmap". 
+    iIntros (Hw) "Hmap".
     iDestruct (big_sepM_lookup_acc (λ (r : RegName) i, r ↦ᵣ i)%I reg r w) as "Hr"; eauto.
     iSpecialize ("Hr" with "[Hmap]"); eauto. iDestruct "Hr" as "[Hw Hmap]".
     iDestruct (big_sepM_insert_acc (λ (r : RegName) i, r ↦ᵣ i)%I reg r w) as "Hupdate"; eauto.
-    iSpecialize ("Hmap" with "[Hw]"); eauto. 
+    iSpecialize ("Hmap" with "[Hw]"); eauto.
     iSpecialize ("Hupdate" with "[Hmap]"); eauto.
   Qed.
-  
+
   Lemma fundamental_cap r p b e a :
     ⊢ interp (WCap p b e a) →
       interp_expression r (WCap p b e a).
@@ -44,8 +44,8 @@ Section fundamental.
     iIntros "[[Hfull Hreg] [Hmreg Hown]]".
     iRevert "Hinv".
     iLöb as "IH" forall (r p b e a).
-    iIntros "#Hinv". 
-    iDestruct "Hfull" as "%". iDestruct "Hreg" as "#Hreg". 
+    iIntros "#Hinv".
+    iDestruct "Hfull" as "%". iDestruct "Hreg" as "#Hreg".
     iApply (wp_bind (fill [SeqCtx])).
     destruct (decide (isCorrectPC (WCap p b e a))).
     - (* Correct PC *)
@@ -54,14 +54,14 @@ Section fundamental.
       assert (p = RX ∨ p = RWX) as Hp.
       { inversion i. subst. auto. }
       iDestruct (read_allowed_inv_regs with "[] Hinv") as (P) "(#Hinva & #Hread)";[eauto|destruct Hp as [-> | ->];auto|iFrame "% #"|].
-      rewrite /interp_ref_inv /=. 
-      iInv (logN.@a) as (w) "[>Ha HP]" "Hcls". 
-      iDestruct ((big_sepM_delete _ _ PC) with "Hmreg") as "[HPC Hmap]"; 
+      rewrite /interp_ref_inv /=.
+      iInv (logN.@a) as (w) "[>Ha HP]" "Hcls".
+      iDestruct ((big_sepM_delete _ _ PC) with "Hmreg") as "[HPC Hmap]";
         first apply (lookup_insert _ _ (WCap p b e a)).
       destruct (decodeInstrW w) eqn:Hi. (* proof by cases on each instruction *)
       + (* Jmp *)
         iApply (jmp_case with "[] [] [] [] [] [Hown] [Ha] [HP] [Hcls] [HPC] [Hmap]");
-          try iAssumption; eauto. 
+          try iAssumption; eauto.
       + (* Jnz *)
         iApply (jnz_case with "[] [] [] [] [] [Hown] [Ha] [HP] [Hcls] [HPC] [Hmap]");
           try iAssumption; eauto.
@@ -173,24 +173,24 @@ Section fundamental.
     p ≠ E -> interp (WCap p b e a) -∗ exec_cond b e p.
   Proof.
     iIntros (Hnp) "#Hw".
-    iIntros (a0 r Hin). iNext. iModIntro. 
-    iApply fundamental. 
+    iIntros (a0 r Hin). iNext. iModIntro.
+    iApply fundamental.
     rewrite !fixpoint_interp1_eq /=. destruct p; try done.
   Qed.
 
   (* We can use the above fact to create a special "jump or fail pattern" when jumping to an unknown adversary *)
-  
+
   Lemma exec_wp p b e a :
     isCorrectPC (WCap p b e a) ->
     exec_cond b e p -∗
     ∀ r, ▷ □ (interp_expr interp r) (WCap p b e a).
-  Proof. 
-    iIntros (Hvpc) "#Hexec". 
+  Proof.
+    iIntros (Hvpc) "#Hexec".
     rewrite /exec_cond.
-    iIntros (r). 
-    assert (a ∈ₐ[[b,e]])%I as Hin. 
+    iIntros (r).
+    assert (a ∈ₐ[[b,e]])%I as Hin.
     { rewrite /in_range. inversion Hvpc; subst. auto. }
-    iSpecialize ("Hexec" $! a r Hin). iFrame "#". 
+    iSpecialize ("Hexec" $! a r Hin). iFrame "#".
   Qed.
 
   (* updatePcPerm adds a later because of the case of E-capabilities, which
@@ -228,12 +228,12 @@ Section fundamental.
     iSplitL "HrV"; [iSplit|].
     { unfold full_map. iIntros (r).
       destruct (decide (r = PC)). { subst r. rewrite lookup_insert //. }
-      rewrite lookup_insert_ne //. iPureIntro. rewrite elem_of_gmap_dom Hrmap. set_solver. }
+      rewrite lookup_insert_ne //. iPureIntro. rewrite -elem_of_dom Hrmap. set_solver. }
     { iIntros (ri v Hri Hvs).
       rewrite lookup_insert_ne // in Hvs.
       iDestruct (big_sepM_lookup _ _ ri with "HrV") as "HrV"; eauto. }
     rewrite insert_insert. iApply big_sepM_insert.
-    { apply elem_of_gmap_dom_none. rewrite Hrmap. set_solver. }
+    { apply not_elem_of_dom. rewrite Hrmap. set_solver. }
     iFrame.
   Qed.
 

--- a/theories/iris_extra.v
+++ b/theories/iris_extra.v
@@ -444,7 +444,7 @@ Proof.
     + done.
     + iDestruct (big_sepM2_dom with "Hmap") as %Hdom.
       assert (is_Some (m' !! a)) as [ρ Hρ].
-      { apply elem_of_gmap_dom. rewrite Hdom dom_insert_L.
+      { apply elem_of_dom. rewrite Hdom dom_insert_L.
         apply elem_of_union_l, elem_of_singleton; auto. }
       rewrite -(insert_id m' a ρ); auto.
       rewrite -insert_delete_insert.
@@ -478,7 +478,7 @@ Proof.
     assert (a ∈ (map_to_list m).*1) as Hin'.
     { rewrite -Hl. constructor. }
     assert (is_Some(m !! a)) as [b' Hsome].
-    { apply elem_of_gmap_dom. rewrite -list_to_set_map_to_list. apply elem_of_list_to_set. auto. }
+    { apply elem_of_dom. rewrite -list_to_set_map_to_list. apply elem_of_list_to_set. auto. }
     iDestruct (big_sepM_delete _ _ a with "Hm") as "[Ha Hm]";eauto.
     iApply big_sepM_delete;[|iFrame].
     { rewrite Hm.  apply lookup_insert. }

--- a/theories/map_simpl.v
+++ b/theories/map_simpl.v
@@ -217,9 +217,9 @@ Local Ltac2 replace_with (lhs: constr) (rhs: constr) :=
 Ltac2 rec make_list_from_unions h x :=
   match! x with
   | union ?a (singleton ?b) =>
-    ltac1:(h b |- try (rewrite (delete_notin _ b); [|simplify_map_eq; rewrite elem_of_gmap_dom_none h; set_solver; fail])) (Ltac1.of_constr h) (Ltac1.of_constr b);
+    ltac1:(h b |- try (rewrite (delete_notin _ b); [|simplify_map_eq; rewrite -not_elem_of_dom h; set_solver; fail])) (Ltac1.of_constr h) (Ltac1.of_constr b);
     make_list_from_unions h a
-  | singleton ?x => ltac1:(h x |- try (rewrite (delete_notin _ x); [|simplify_map_eq; rewrite elem_of_gmap_dom_none h; set_solver+; fail])) (Ltac1.of_constr h) (Ltac1.of_constr x)
+  | singleton ?x => ltac1:(h x |- try (rewrite (delete_notin _ x); [|simplify_map_eq; rewrite -not_elem_of_dom h; set_solver+; fail])) (Ltac1.of_constr h) (Ltac1.of_constr x)
   end.
 
 Ltac2 post_process k m :=

--- a/theories/register_tactics.v
+++ b/theories/register_tactics.v
@@ -74,7 +74,7 @@ Ltac extract_pointsto_map regs Hmap rname Hrdom Hreg :=
   let rval := fresh "v"rname in
   let Hsome := fresh "Hsome" in
   first [ eassert (regs !! rname = Some _) as Hsome by solve_lookup_some (* Try to reuse existing value, if any *) |
-  assert (is_Some (regs !! rname)) as [rval Hsome] by (rewrite elem_of_gmap_dom Hrdom; set_solver +) ];
+  assert (is_Some (regs !! rname)) as [rval Hsome] by (rewrite -elem_of_dom Hrdom; set_solver +) ];
   let str_destr := constr:(("[" ++ Hreg ++ " " ++ Hmap ++ "]")%string) in
   iDestruct (big_sepM_delete _ _ rname with Hmap) as str_destr; first exact Hsome; clear Hsome.
 
@@ -117,7 +117,7 @@ Tactic Notation "iExtractList" constr(Hmap) constr(rnames) "as" constr(Hregs):=
 
 Ltac insert_pointsto_map regs Hmap rname Hrdom Hreg :=
   let Hsome := fresh "Hsome" in
-  assert (regs !! rname = None) as Hsome by (rewrite elem_of_gmap_dom_none Hrdom; set_solver +);
+  assert (regs !! rname = None) as Hsome by (rewrite -not_elem_of_dom Hrdom; set_solver +);
   let str_destr := constr:(("[ $" ++ Hmap ++ " $" ++ Hreg ++ "]")%string) in
   iDestruct (big_sepM_insert _ _ rname with str_destr) as Hmap; first exact Hsome; clear Hsome.
 

--- a/theories/rules/rules_Load.v
+++ b/theories/rules/rules_Load.v
@@ -56,7 +56,7 @@ Section cap_lang_rules.
   Definition allow_load_map_or_true r (regs : Reg) (mem : gmap Addr Word):=
     ∃ p b e a, read_reg_inr regs r p b e a ∧
       if decide (reg_allows_load regs r p b e a) then
-        ∃ w, mem !! a = Some w 
+        ∃ w, mem !! a = Some w
       else True.
 
   Lemma allow_load_implies_loadv:
@@ -194,7 +194,7 @@ Section cap_lang_rules.
     feed destruct (Hri r1) as [r1v [Hr'1 _]]. by set_solver+. clear Hri.
     (* Derive the PC in memory *)
     assert (is_Some (dfracs !! pc_a)) as [dq Hdq].
-    { apply elem_of_gmap_dom. rewrite -Hdomeq. apply elem_of_gmap_dom;eauto. }
+    { apply elem_of_dom. rewrite -Hdomeq. apply elem_of_dom;eauto. }
     assert (prod_merge dfracs mem !! pc_a = Some (dq,w)) as Hmem_dpc.
     { rewrite lookup_merge Hmem_pc Hdq //. }
     iDestruct (gen_mem_valid_inSepM_general (prod_merge dfracs mem) m with "Hm Hmem") as %Hma; eauto.
@@ -232,7 +232,7 @@ Section cap_lang_rules.
     pose proof (allow_load_implies_loadv r2 mem regs p b e a) as (loadv & Hmema); auto.
 
     assert (is_Some (dfracs !! a)) as [dq' Hdq'].
-    { apply elem_of_gmap_dom. rewrite -Hdomeq. apply elem_of_gmap_dom;eauto. }
+    { apply elem_of_dom. rewrite -Hdomeq. apply elem_of_dom;eauto. }
     assert (prod_merge dfracs mem !! a = Some (dq',loadv)) as Hmemadq.
     { rewrite lookup_merge Hmema Hdq' //. }
     iDestruct (gen_mem_valid_inSepM_general (prod_merge dfracs mem) m a loadv with "Hm Hmem" ) as %Hma' ; eauto.

--- a/theories/seal_store.v
+++ b/theories/seal_store.v
@@ -44,18 +44,18 @@ Lemma gmap_none_convert `{Countable K} {A B: Type} (g1 : gmap K A) (g2 : gmap K 
     g1 !! i = None → g2 !! i = None.
 Proof.
   intros Hdom Hnon.
-  apply elem_of_gmap_dom_none in Hnon.
+  apply not_elem_of_dom in Hnon.
   rewrite Hdom in Hnon.
-  by apply elem_of_gmap_dom_none.
+  by apply not_elem_of_dom.
 Qed.
 
 Lemma gmap_isSome_convert `{Countable K} {A B: Type} (g1 : gmap K A) (g2 : gmap K B) (i : K): dom g1 = dom g2 →
     is_Some (g1 !! i) → is_Some (g2 !! i).
 Proof.
   intros Hdom Hnon.
-  apply elem_of_gmap_dom in Hnon.
+  apply elem_of_dom in Hnon.
   rewrite Hdom in Hnon.
-  by apply elem_of_gmap_dom.
+  by apply elem_of_dom.
 Qed.
 
 Section Store.

--- a/theories/stdpp_extra.v
+++ b/theories/stdpp_extra.v
@@ -647,35 +647,6 @@ Proof.
   - cbn [create_gmap_default list_to_set]. rewrite dom_insert_L // IHl //.
 Qed.
 
-Lemma map_filter_sub :
-∀ (K : Type) (M : Type → Type) (H : FMap M) (H0 :
-                                             ∀ A : Type,
-                                               Lookup K A (M A))
-  (H1 : ∀ A : Type, Empty (M A)) (H2 : ∀ A : Type, PartialAlter K A (M A))
-  (H3 : OMap M) (H4 : Merge M) (H5 : ∀ A : Type, FinMapToList K A (M A))
-  (EqDecision0 : EqDecision K),
-  FinMap K M →
-  ∀ (A : Type) (P : K * A → Prop) (H7 : ∀ x : K * A, Decision (P x))
-    (m : M A),
-    filter P m ⊆ m.
-Proof.
-  intros. eapply map_subseteq_spec. intros ? ? ?.
-  eapply map_filter_lookup_Some_1_1; eauto.
-Qed.
-
-Lemma map_filter_id :
-  ∀ (K : Type) (M : Type → Type) (H : FMap M) (H0 : ∀ A : Type, Lookup K A (M A)) (H1 : ∀ A : Type, Empty (M A)) (H2 : ∀ A : Type, PartialAlter K A (M A))
-    (H3 : OMap M) (H4 : Merge M) (H5 : ∀ A : Type, FinMapToList K A (M A)) (EqDecision0 : EqDecision K),
-    FinMap K M
-    → ∀ (A : Type) (P : K * A → Prop) (H7 : ∀ x : K * A, Decision (P x)) (m : M A),
-      (∀ i x, m !! i = Some x → P (i, x)) → filter P m = m.
-Proof.
-  intros. apply map_eq.
-  intros i. destruct (m !! i) eqn:Hsome.
-  - apply map_filter_lookup_Some_2;auto.
-  - apply map_filter_lookup_None_2;auto.
-Qed.
-
 Lemma fst_zip_prefix A B (l : list A) (k : list B) :
   (zip l k).*1 `prefix_of` l.
 Proof.

--- a/theories/stdpp_extra.v
+++ b/theories/stdpp_extra.v
@@ -55,28 +55,6 @@ Proof.
   simpl. destruct (decide (P x)); rewrite /filter; try congruence.
 Qed.
 
-Lemma elem_of_gmap_dom {K V : Type} `{EqDecision K} `{Countable K}
-      (m : gmap K V) (i : K) :
-  is_Some (m !! i) ↔ i ∈ dom m.
-Proof.
-  split.
-  - intros [x Hsome].
-    apply elem_of_dom. eauto.
-  - intros Hin. by apply elem_of_dom in Hin.
-Qed.
-
-Lemma elem_of_gmap_dom_none {K V : Type} `{EqDecision K} `{Countable K}
-      (m : gmap K V) (i : K) :
-  m !! i = None ↔ i ∉ dom m.
-Proof.
-  split.
-  - intros Hnone. intros Hcontr%elem_of_gmap_dom.
-    rewrite Hnone in Hcontr. inversion Hcontr. congruence.
-  - intros Hdom. destruct (m !! i) eqn:Hnone;auto.
-    assert (is_Some (m !! i)) as HisSome;eauto.
-    apply elem_of_gmap_dom in HisSome. contradiction.
-Qed.
-
 Lemma dom_map_imap_full {K A B}
       `{Countable A, EqDecision A, Countable B, EqDecision B, Countable K, EqDecision K}
       (f: K -> A -> option B) (m: gmap K A):
@@ -85,7 +63,7 @@ Lemma dom_map_imap_full {K A B}
 Proof.
   intros Hf.
   apply set_eq. intros k.
-  rewrite -!elem_of_gmap_dom map_lookup_imap.
+  rewrite !elem_of_dom map_lookup_imap.
   destruct (m !! k) eqn:Hmk.
   - destruct (Hf k a Hmk) as [? Hfk]. cbn. rewrite Hfk. split; eauto.
   - cbn. split; inversion 1; congruence.
@@ -337,13 +315,13 @@ Proof.
   apply (@anti_symm _ _ subseteq).
   typeclasses eauto.
   { rewrite elem_of_subseteq. intro k.
-    rewrite -elem_of_gmap_dom. intros [v Hv].
+    rewrite elem_of_dom. intros [v Hv].
     rewrite difference_het_lookup_Some in Hv *.
     destruct Hv as [? ?].
-    rewrite elem_of_difference -!elem_of_gmap_dom. split; eauto.
+    rewrite elem_of_difference !elem_of_dom. split; eauto.
     intros [? ?]. congruence. }
   { rewrite elem_of_subseteq. intro k.
-    rewrite elem_of_difference -!elem_of_gmap_dom. intros [[v ?] Hcontra].
+    rewrite elem_of_difference !elem_of_dom. intros [[v ?] Hcontra].
     exists v. rewrite difference_het_lookup_Some. split; eauto.
     destruct (m2 !! k) eqn:?; eauto. exfalso. apply Hcontra. eauto. }
 Qed.
@@ -363,7 +341,7 @@ Proof.
     rewrite difference_het_insert_r.
     rewrite dom_insert in Hm1l *.
     move: Hm1l. rewrite elements_union_singleton.
-    rewrite -elem_of_gmap_dom; intros [? ?]; congruence.
+    rewrite elem_of_dom; intros [? ?]; congruence.
     intros Hm1l.
     transitivity (delete k (delete_list (elements (dom m2)) m1)).
     { erewrite delete_list_permutation. 2: eauto. reflexivity. }

--- a/theories/stdpp_extra.v
+++ b/theories/stdpp_extra.v
@@ -1,16 +1,6 @@
 From Coq Require Import ssreflect.
 From stdpp Require Import countable gmap list.
 
-Lemma elements_list_to_set {A} `{Countable A} (l: list A) :
-  NoDup l →
-  elements (list_to_set l : gset A) ≡ₚ l.
-Proof.
-  induction l.
-  - intros. rewrite list_to_set_nil elements_empty //.
-  - intros ND. rewrite list_to_set_cons elements_union_singleton.
-    + rewrite not_elem_of_list_to_set. by apply NoDup_cons_1_1.
-    + rewrite IHl //. eauto using NoDup_cons_1_2.
-Qed.
 
 Lemma list_to_map_lookup_is_Some {A B} `{Countable A, EqDecision A} (l: list (A * B)) (a: A) :
   is_Some ((list_to_map l : gmap A B) !! a) ↔ a ∈ l.*1.
@@ -37,14 +27,6 @@ Proof.
   revert l2. induction l1; intros l2 Hl2; auto.
   destruct l2; cbn in Hl2. exfalso; lia.
   cbn. rewrite IHl1; auto. lia.
-Qed.
-
-Lemma list_filter_app { A: Type } (P: A -> Prop) `{ forall x, Decision (P x) } l1 l2:
-  @list_filter _ P _ (l1 ++ l2) = @list_filter _ P _ l1 ++ @list_filter _ P _ l2.
-Proof.
-  induction l1; simpl; auto.
-  destruct (decide (P a)); auto.
-  unfold filter. rewrite IHl1. auto.
 Qed.
 
 Lemma list_filter_forall { A: Type } (P: A -> Prop) `{ forall x, Decision (P x) } l:


### PR DESCRIPTION
Some lemmas from `stdpp_extra.v` have been added to `stdpp` and aren't needed anymore. This PR removes them.

Short list: stdpp_extra lemma -> stdpp lemma
- `elem_of_gmap_dom` -> `elem_of_dom` (flipped)
- `elem_of_gmap_dom_none` -> `not_elem_of_dom` (flipped)
- `map_filter_sub` -> `map_filter_subseteq`
- `map_filter_id` -> `map_filter_id`
- `elem_of_list_to_set` -> `elem_of_list_to_set`
- `list_filter_app` -> `filter_app`