### PR TITLE
Opsem for attestation instructions and skeleton for WP of EStoreId

### DIFF
--- a/tests/proofmode_focus_block.v
+++ b/tests/proofmode_focus_block.v
@@ -6,7 +6,7 @@ Definition i1 `{MP: MachineParameters} := encodeInstrsW [ Mov r_t2 1; Mov r_t2 0
 Definition i2 `{MP: MachineParameters} := encodeInstrsW [ Mov r_t3 1; Mov r_t3 0 ].
 Definition l2 `{MP: MachineParameters} := i1 ++ i2.
 
-Lemma foo {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} `{MP: MachineParameters} p b e a :
+Lemma foo {Σ:gFunctors} {ceriseg:ceriseG Σ} `{MP: MachineParameters} p b e a :
   {{{ ⌜ExecPCPerm p ∧ SubBounds b e a (a ^+ length (l1 ++ l2))%a⌝
       ∗ codefrag a (l1 ++ l2)
       ∗ PC ↦ᵣ WCap (p,b,e,(a ^+ length l1)%a) }}}

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -989,6 +989,19 @@ Section opsem.
     all: repeat destruct (mem _ !! _); cbn in *; repeat case_match.
     all: simplify_eq; try by exfalso.
     all: try apply updatePC_some in Heqo as [φ' Heqo]; eauto.
+    all: repeat (
+             destruct (mem _ !! _); cbn in *; repeat case_match
+             ; simplify_eq
+             ; cbn in *
+             ; case_match).
+    all: repeat destruct (finz.of_z _); cbn in *
+    ; repeat destruct (has_seal _); cbn in *
+    ; repeat destruct (tindex_of_eid _); cbn in *
+    ; repeat destruct (eid_of_enum _); cbn in *
+    ; repeat destruct (get_wcap_scap _); cbn in *.
+    all: repeat destruct p.
+    all: try apply updatePC_some in Heqo as [φ' Heqo]; eauto.
+    all: simplify_eq; try by exfalso.
   Qed.
 
 End opsem.
@@ -1064,6 +1077,6 @@ Proof.
             {| reg := gmap_empty ;
               mem := gmap_empty ;
               etable := gmap_empty ;
-              enumcur := _ |}).
-  eexists. Unshelve. 3: exact 0%Z. all: solve_finz.
+              enumcur := 0%Z |}).
+  (* eexists. Unshelve. 3: exact 0%Z. all: solve_finz. *)
 Defined.

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -473,13 +473,10 @@ Section opsem.
                   then (finz_div_nat oa 2)
                   else finz_div_nat (oa^-1)%f 2.
 
-  (* Definition has_seal : Word -> option ENum := *)
-  (*   λ σ, (match σ with *)
-  (*         | WSealRange _ _ _ oa => seal_of_oa oa *)
-  (*         | _ => None (* rs does not contain seals *) *)
-  (*         end). *)
-
-  Axiom measure : Mem -> Addr -> Addr -> Z.
+  (* measure m b e : hash (b || m[b+1::e])*)
+  Axiom measure: Mem -> Addr -> Addr -> Z.
+  (* Axiom measure (m : Mem) (b e: Addr) : Z. *)
+    (* hash_concat (hash b) (hash (b^+1::e)). *)
 
   Definition id_of_eid (etable : ETable) (enum : ENum) : option EId :=
    map_fold
@@ -693,8 +690,8 @@ Section opsem.
     let seals := (WSealRange (true, true) s_b s_e s_b) in (* permitSeal & permitUnseal *)
 
     (* MEASURE THE CODE FOOTPRINT OF THE ENCLAVE *)
-    incr_b ← finz.of_z (b+1);
-    let identity := measure (mem φ) incr_b e in
+    (* incr_b ← finz.of_z (b+1); *)
+    let identity := measure (mem φ) b e in
 
     fresh_idx ← gen_fresh_idx (etable φ); (* generate a fresh index in the ETable *)
 

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -727,10 +727,11 @@ Section opsem.
        (* exclude registers, but also the address a itself !! *)
       wsrc          ← (reg φ) !! src;
       '(p, b, e, a) ← get_wcap_scap wsrc; (* TODO ask: does IsUnique also work with sealed cap ? *)
-           (* cf. Sail: https://github.com/proteus-core/cheritree/blob/e969919a30191a4e0ceec7282bb9ce982db0de73/sail/sail-cheri-riscv/src/cheri_insts.sail#L2414-L2428
-         *)
-      φ |>> update_reg dst (WInt 1%Z)
+      let uniqueb := (sweep_reg (mem φ) (reg φ) src) in
+      φ |>> update_reg dst (WInt (if uniqueb then 1%Z else 0%Z))
         |>> updatePC
+      (* cf. Sail: https://github.com/proteus-core/cheritree/blob/e969919a30191a4e0ceec7282bb9ce982db0de73/sail/sail-cheri-riscv/src/cheri_insts.sail#L2414-L2428
+       *)
   end.
 
   Definition exec (i : instr) (φ : ExecConf) : Conf :=

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -25,7 +25,7 @@ Definition Conf: Type := ConfFlag * ExecConf.
 Definition update_regs (φ: ExecConf) (reg' : Reg) : ExecConf := MkExecConf reg' (mem φ) (etable φ) (enumcur φ).
 Definition update_reg (φ: ExecConf) (r: RegName) (w: Word): ExecConf := update_regs φ (<[ r := w ]> (reg φ)).
 Definition update_mem (φ: ExecConf) (a: Addr) (w: Word): ExecConf := MkExecConf (reg φ) (<[a:=w]>(mem φ)) (etable φ) (enumcur φ).
-Definition update_etable (φ: ExecConf) (i: TIndex) (eid : EId) : ExecConf := MkExecConf (reg φ) (mem φ) (<[i := eid]> (etable φ)) (enumcur φ).
+Definition update_etable (φ: ExecConf) (i: TIndex) (eid : EIdentity) : ExecConf := MkExecConf (reg φ) (mem φ) (<[i := eid]> (etable φ)) (enumcur φ).
 Definition remove_from_etable (φ : ExecConf) (i : TIndex) : ExecConf :=
    match φ with
    | {| reg := reg; mem := mem; etable := etable; enumcur := enumcur |} =>
@@ -440,7 +440,7 @@ Section opsem.
   Definition no_cap (mem : Mem) (b: Addr) (e : Addr) : bool :=
     bool_decide (not (contains_cap mem b e)).
 
-  Definition retrieve_eid (i : TIndex) (tb : ETable) : option EId :=
+  Definition retrieve_eid (i : TIndex) (tb : ETable) : option EIdentity :=
     match (tb !! i) with
     | Some p => Some p
     | None => None

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -689,12 +689,11 @@ Section opsem.
     let identity := measure (mem φ) incr_b e in
 
     fresh_idx ← gen_fresh_idx (etable φ); (* generate a fresh index in the ETable *)
-    let incr_ec := ((enumcur φ)+1)%Z in
 
     (* UPDATE THE MACHINE STATE *)
     φ  |>> update_mem b' seals    (* store seals at base address of enclave's data sec.*)
        |>> update_etable fresh_idx identity ec (* create a new index in the ETable *)
-       |>> update_enumcur incr_ec  (* EC := EC + 1 *)
+       |>> update_enumcur ((enumcur φ)+1)%Z  (* EC := EC + 1 *)
        |>> update_reg rd (WCap E b e a) (* Position cursor at address a: client specifies entry point *)
        |>> updatePC
 

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -689,7 +689,7 @@ Section opsem.
   | IsUnique dst src =>
        (* exclude registers, but also the address a itself !! *)
       wsrc          ← (reg φ) !! src;
-      '(p, b, e, a) ← get_wcap_scap wsrc; (* TODO ask: does IsUnique also work with sealed cap ? *)
+      '(p, b, e, a) ← get_wcap_scap wsrc;
       let uniqueb := (sweep_reg (mem φ) (reg φ) src) in
       φ |>> update_reg dst (WInt (if uniqueb then 1%Z else 0%Z))
         |>> updatePC
@@ -702,25 +702,6 @@ Section opsem.
     | None => (Failed, φ)
     | Some conf => conf
     end.
-
-  (* Definition exec (i: instr) (φ: ExecConf) : Conf := *)
-  (*    match exec_opt i φ with *)
-  (*    | None => *)
-  (*        match i with *)
-  (*        | EInit _ _ => (* failure retains initial machine state @TODO: what happens to PC? *) *)
-  (*            match (φ |>> updatePC) with *)
-  (*            | Some conf => conf *)
-  (*            | None => (Failed, φ) *)
-  (*            end *)
-  (*        | EDeInit rd _ | EStoreId rd _ _ | IsUnique rd _ => *)
-  (*            match (φ |>> update_reg rd (WInt 0) |>> updatePC) with (* write 0 to RD register *) *)
-  (*            | Some conf => conf *)
-  (*            | None => (Failed, φ) *)
-  (*            end *)
-  (*        | _ => (Failed, φ) *)
-  (*                 end *)
-  (*    | Some conf => conf *)
-  (*    end . *)
 
   Lemma exec_opt_exec_some :
     forall φ i c,

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -473,11 +473,14 @@ Section opsem.
                   then (finz_div_nat oa 2)
                   else finz_div_nat (oa^-1)%f 2.
 
-  (* TODO *)
-  Axiom measure: Mem -> Addr -> Addr -> Z.
-  (* incr_b ← finz.of_z (b+1); *)
-  (* Axiom measure (m : Mem) (b e: Addr) : Z. *)
-    (* hash_concat (hash b) (hash (b^+1::e)). *)
+  (* Axiom measure: Mem -> Addr -> Addr -> Z. *)
+  Definition measure (m : Mem) (b e: Addr) :=
+    let instructions : list Word :=
+      map snd
+        ((map_to_list
+            (filter (fun '(a, _) => a ∈ (finz.seq_between (b^+1)%a e)) m)))
+    in
+    hash_concat (hash b) (hash instructions).
 
   Definition id_of_eid (etable : ETable) (enum : ENum) : option EId :=
    map_fold

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -657,9 +657,7 @@ Section opsem.
     fresh_tid ← gen_fresh_tid φ; (* generate a fresh index in the ETable *)
 
     (* UPDATE THE MACHINE STATE *)
-      (* φ |>> updatePC *)
-    φ
-      (* |>> update_mem b' seals    (* store seals at base address of enclave's data sec.*) *)
+    φ  |>> update_mem b' seals    (* store seals at base address of enclave's data sec.*)
        |>> update_etable fresh_tid eid (* create a new index in the ETable *)
        |>> update_enumcur ((enumcur φ)+1)  (* EC := EC + 1 *)
        |>> update_reg rd (WCap E b e a) (* Position cursor at address a: client specifies entry point *)

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -629,12 +629,12 @@ Section opsem.
     (* obtain RX_ permissions for code section *)
     ccap          ← (reg φ) !! rs; (* get code capability *)
     '(p, b, e, a) ← get_wcap ccap;
-    when (readAllowed p && executeAllowed p) then
+    when (readAllowed p && executeAllowed p && negb (writeAllowed p)) then
 
     (* obtain RW_ permissions for data section *)
     dcap              ← (mem φ) !! b;
     '(p', b', e', a') ← get_wcap dcap;
-    when (readAllowed p' && writeAllowed p') then
+    when (readAllowed p' && writeAllowed p' && negb (executeAllowed p')) then
 
     (* MEMORY SWEEP *)
     when ( (sweep_addr (mem φ) (reg φ) b) && (* sweep the memory excluding the data cap at location b *)

--- a/theories/cap_lang.v
+++ b/theories/cap_lang.v
@@ -34,8 +34,8 @@ Definition remove_from_etable (φ : ExecConf) (i : TIndex) : ExecConf :=
 
 (* global freshness, alt: axiomatize a freshness function
    -- keeps it implementation independent *)
-Definition gen_fresh_idx {K V} `{EqDecision K} `{Countable K} (m : gmap K V) : option ENum :=
-  Some (map_fold (λ _ _ n, 1 + n) 1 m)%Z.
+Definition gen_fresh_idx (φ: ExecConf) : option ENum :=
+  Some (enumcur φ).
 
 Definition update_enumcur (φ: ExecConf) (enumcur : ENum): ExecConf := MkExecConf (reg φ) (mem φ) (etable φ) enumcur.
 
@@ -473,8 +473,9 @@ Section opsem.
                   then (finz_div_nat oa 2)
                   else finz_div_nat (oa^-1)%f 2.
 
-  (* measure m b e : hash (b || m[b+1::e])*)
+  (* TODO *)
   Axiom measure: Mem -> Addr -> Addr -> Z.
+  (* incr_b ← finz.of_z (b+1); *)
   (* Axiom measure (m : Mem) (b e: Addr) : Z. *)
     (* hash_concat (hash b) (hash (b^+1::e)). *)
 
@@ -690,10 +691,9 @@ Section opsem.
     let seals := (WSealRange (true, true) s_b s_e s_b) in (* permitSeal & permitUnseal *)
 
     (* MEASURE THE CODE FOOTPRINT OF THE ENCLAVE *)
-    (* incr_b ← finz.of_z (b+1); *)
     let identity := measure (mem φ) b e in
 
-    fresh_idx ← gen_fresh_idx (etable φ); (* generate a fresh index in the ETable *)
+    fresh_idx ← gen_fresh_idx φ; (* generate a fresh index in the ETable *)
 
     (* UPDATE THE MACHINE STATE *)
     φ  |>> update_mem b' seals    (* store seals at base address of enclave's data sec.*)

--- a/theories/examples/adder.v
+++ b/theories/examples/adder.v
@@ -5,7 +5,7 @@ From cap_machine Require Import rules logrel macros fundamental.
 From cap_machine.proofmode Require Import tactics_helpers.
 
 Section adder.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/arch_sealing.v
+++ b/theories/examples/arch_sealing.v
@@ -10,7 +10,7 @@ Import uPred. (* exist_persistent *)
 
 (* Architectural variant of the sealing/unsealing functionality in the dynamic_sealing file. *)
 Section sealing.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters} .
 

--- a/theories/examples/assert.v
+++ b/theories/examples/assert.v
@@ -7,7 +7,7 @@ From cap_machine Require Import logrel addr_reg_sample fundamental rules proofmo
 (* Maintains a flag storing whether an assert has failed. *)
 
 Section Assert.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/buffer.v
+++ b/theories/examples/buffer.v
@@ -8,7 +8,7 @@ From cap_machine Require Import proofmode.
 Open Scope Z_scope.
 
 Section buffer.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           `{MP: MachineParameters}.
 
   Definition buffer_code (off: Z) : list LWord :=

--- a/theories/examples/call.v
+++ b/theories/examples/call.v
@@ -4,7 +4,7 @@ From cap_machine Require Import logrel macros rules.
 From cap_machine.proofmode Require Import tactics_helpers proofmode.
 
 Section call.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/callback.v
+++ b/theories/examples/callback.v
@@ -5,7 +5,7 @@ From cap_machine Require Import rules logrel macros call.
 From cap_machine.proofmode Require Import tactics_helpers.
 
 Section callback.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/counter/counter.v
+++ b/theories/examples/counter/counter.v
@@ -5,7 +5,7 @@ From cap_machine Require Import rules logrel macros fundamental.
 From cap_machine.proofmode Require Import tactics_helpers.
 
 Section counter.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/counter/counter_preamble.v
+++ b/theories/examples/counter/counter_preamble.v
@@ -9,7 +9,7 @@ From cap_machine.proofmode Require Import tactics_helpers.
 From stdpp Require Import countable.
 
 Section counter_example_preamble.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/counter_binary/counter_binary.v
+++ b/theories/examples/counter_binary/counter_binary.v
@@ -7,7 +7,7 @@ From cap_machine.proofmode Require Import tactics_helpers.
 
 
 Section counter.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/counter_binary/counter_binary_preamble.v
+++ b/theories/examples/counter_binary/counter_binary_preamble.v
@@ -9,7 +9,7 @@ From cap_machine.examples.counter_binary Require Import counter_binary counter_b
 From stdpp Require Import countable.
 
 Section counter_example_preamble.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/counter_binary/counter_binary_preamble_def.v
+++ b/theories/examples/counter_binary/counter_binary_preamble_def.v
@@ -9,7 +9,7 @@ From cap_machine.examples.counter_binary Require Import counter_binary.
 From stdpp Require Import countable.
 
 Section counter_example_preamble.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/counter_binary/counter_binary_preamble_left.v
+++ b/theories/examples/counter_binary/counter_binary_preamble_left.v
@@ -9,7 +9,7 @@ From cap_machine.examples.counter_binary Require Import counter_binary counter_b
 From stdpp Require Import countable.
 
 Section counter_example_preamble.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/dynamic_sealing.v
+++ b/theories/examples/dynamic_sealing.v
@@ -8,7 +8,7 @@ From cap_machine.proofmode Require Import tactics_helpers solve_pure proofmode c
 
 Section sealing.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}
           {seals:sealStoreG Σ}

--- a/theories/examples/enclaves/trusted_compute.v
+++ b/theories/examples/enclaves/trusted_compute.v
@@ -8,7 +8,7 @@ From cap_machine Require Import macros_new.
 Open Scope Z_scope.
 
 Section trusted_compute_example.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg : sealStoreG Σ} `{MP: MachineParameters}.
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg : sealStoreG Σ} `{MP: MachineParameters}.
 
   (* Data part, following the directly the main code *)
   Definition trusted_compute_data (linking_table_cap : LWord) : list LWord :=

--- a/theories/examples/interval/interval.v
+++ b/theories/examples/interval/interval.v
@@ -11,7 +11,7 @@ Notation "a ↪ₐ w" := (mapsto (L:=Addr) (V:=Word) a DfracDiscarded w) (at lev
 
 Section interval.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           {nainv: logrel_na_invs Σ} (* `{intg: intervalG Σ} *)
           `{MP: MachineParameters}
           {mono : sealLLG Σ}.

--- a/theories/examples/interval/interval_client.v
+++ b/theories/examples/interval/interval_client.v
@@ -8,7 +8,7 @@ From cap_machine.examples.interval Require Import interval interval_closure.
 From cap_machine Require Import contiguous tactics_helpers solve_pure proofmode map_simpl.
 
 Section interval_client.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ} {sealG: sealLLG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/interval/interval_client_adequacy.v
+++ b/theories/examples/interval/interval_client_adequacy.v
@@ -355,7 +355,7 @@ Proof.
 Qed.
 
 Section int_client_adequacy.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg:sealStoreG Σ}
           {nainv: logrel_na_invs Σ} {sealLLG: keylist.sealLLG Σ}
           `{memlayout: memory_layout}.
 

--- a/theories/examples/interval/interval_client_closure.v
+++ b/theories/examples/interval/interval_client_closure.v
@@ -9,7 +9,7 @@ From cap_machine.proofmode Require Import
   contiguous tactics_helpers solve_pure proofmode map_simpl.
 
 Section interval_client.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg : sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg : sealStoreG Σ}
           {nainv: logrel_na_invs Σ} {sealG: sealLLG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/interval/interval_closure.v
+++ b/theories/examples/interval/interval_closure.v
@@ -8,7 +8,7 @@ From cap_machine.examples Require Import dynamic_sealing keylist malloc.
 From cap_machine.examples.interval Require Import interval.
 
 Section interval_closure.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {sealG: sealLLG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/interval_arch/interval_arch.v
+++ b/theories/examples/interval_arch/interval_arch.v
@@ -11,7 +11,7 @@ Notation "a ↪ₐ w" := (mapsto (L:=Addr) (V:=Word) a DfracDiscarded w) (at lev
 
 Section interval.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           {nainv: logrel_na_invs Σ} (* `{intg: intervalG Σ} *)
           `{MP: MachineParameters}.
 

--- a/theories/examples/interval_arch/interval_client_adequacy_arch.v
+++ b/theories/examples/interval_arch/interval_client_adequacy_arch.v
@@ -395,7 +395,7 @@ Proof.
 Qed.
 
 Section int_client_adequacy.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg:sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{memlayout: memory_layout}.
 

--- a/theories/examples/interval_arch/interval_client_arch.v
+++ b/theories/examples/interval_arch/interval_client_arch.v
@@ -9,7 +9,7 @@ From cap_machine.examples Require Import arch_sealing malloc.
 From cap_machine.examples.interval_arch Require Import interval_arch interval_closure_arch.
 
 Section interval_client.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/interval_arch/interval_client_closure_arch.v
+++ b/theories/examples/interval_arch/interval_client_closure_arch.v
@@ -9,7 +9,7 @@ From cap_machine.examples Require Import arch_sealing malloc.
 From cap_machine.examples.interval_arch Require Import interval_arch interval_closure_arch interval_client_arch.
 
 Section interval_client.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg : sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg : sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/interval_arch/interval_closure_arch.v
+++ b/theories/examples/interval_arch/interval_closure_arch.v
@@ -9,7 +9,7 @@ From cap_machine.examples Require Import arch_sealing malloc.
 From cap_machine.examples.interval_arch Require Import interval_arch.
 
 Section interval_closure.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/isunique_example.v
+++ b/theories/examples/isunique_example.v
@@ -7,7 +7,7 @@ From cap_machine Require Import proofmode.
 Open Scope Z_scope.
 
 Section reclaim_buffer_example.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           `{MP: MachineParameters}.
 
   Definition reclaim_buffer_code : list LWord :=

--- a/theories/examples/keylist.v
+++ b/theories/examples/keylist.v
@@ -10,7 +10,7 @@ Definition prefR (al al' : addrwordLO) := al `prefix_of` al'.
 Class sealLLG Σ := CCounterG { ccounter_inG :: inG Σ (authUR (monotoneUR prefR)) }.
 
 Section list.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}
           {mono : sealLLG Σ}.

--- a/theories/examples/lse.v
+++ b/theories/examples/lse.v
@@ -4,7 +4,7 @@ From cap_machine Require Import rules logrel macros fundamental call callback.
 From cap_machine.proofmode Require Import tactics_helpers.
 
 Section roe.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/lse_adequacy.v
+++ b/theories/examples/lse_adequacy.v
@@ -163,7 +163,7 @@ Next Obligation.
 Qed.
 
 Section roe_adequacy.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{memlayout: memory_layout}.
 

--- a/theories/examples/macros.v
+++ b/theories/examples/macros.v
@@ -6,7 +6,7 @@ From cap_machine.proofmode Require Import tactics_helpers map_simpl solve_pure.
 From cap_machine Require Export iris_extra addr_reg_sample contiguous malloc assert.
 
 Section macros.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/macros_binary.v
+++ b/theories/examples/macros_binary.v
@@ -20,7 +20,7 @@ Ltac iEpilogue_s :=
    iSimpl in "Hj".
 
 Section macros.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/macros_new.v
+++ b/theories/examples/macros_new.v
@@ -6,7 +6,7 @@ From cap_machine Require Export iris_extra addr_reg_sample contiguous malloc sal
 From cap_machine.proofmode Require Import classes tactics_helpers solve_pure proofmode map_simpl.
 
 Section macros.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {seals:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {seals:sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/malloc.v
+++ b/theories/examples/malloc.v
@@ -17,7 +17,7 @@ From cap_machine Require Import logrel addr_reg_sample fundamental rules proofmo
    studies. *)
 
 Section SimpleMalloc.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/malloc_binary.v
+++ b/theories/examples/malloc_binary.v
@@ -7,7 +7,7 @@ From cap_machine Require Import iris_extra logrel_binary fundamental_binary.
 From cap_machine.rules Require Import rules_base.
 
 Section SimpleMalloc.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfg : cfgSG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/minimal_counter.v
+++ b/theories/examples/minimal_counter.v
@@ -7,7 +7,7 @@ From cap_machine Require Import proofmode.
 Open Scope Z_scope.
 
 Section counter.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg:sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/ocpl_lowval_like.v
+++ b/theories/examples/ocpl_lowval_like.v
@@ -16,7 +16,7 @@ From cap_machine.proofmode Require Import tactics_helpers.
 *)
 
 Section rules.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealg:sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealg:sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/examples/salloc.v
+++ b/theories/examples/salloc.v
@@ -17,7 +17,7 @@ From cap_machine Require Import logrel addr_reg_sample fundamental rules proofmo
    studies. *)
 
 Section SimpleSalloc.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/exercises/cerise_modularity.v
+++ b/theories/exercises/cerise_modularity.v
@@ -14,7 +14,7 @@ From cap_machine.proofmode Require Import
 Open Scope Z_scope.
 
 Section increment_macro.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (** The increment macro is a macro that takes a register r (r ≠ r_env), which
@@ -159,7 +159,7 @@ Section increment_macro.
 End increment_macro.
 
 Section rclear_macro.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (** In this section, we will use a pre-defined macro in Cerise, `rclear`.
@@ -205,7 +205,7 @@ Section rclear_macro.
 End rclear_macro.
 
 Section linking_table.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (* Demo with incr_macro for the setup *)

--- a/theories/exercises/cerise_modularity_solutions.v
+++ b/theories/exercises/cerise_modularity_solutions.v
@@ -13,7 +13,7 @@ From cap_machine.proofmode Require Import proofmode tactics_helpers register_tac
 Open Scope Z_scope.
 
 Section increment_macro.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (** The increment macro is a macro that takes a register r (r ≠ r_env), which
@@ -184,7 +184,7 @@ Section increment_macro.
 End increment_macro.
 
 Section rclear_macro.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (** In this section, we will use a pre-defined macro in Cerise, `rclear`.
@@ -330,7 +330,7 @@ Section rclear_macro.
 End rclear_macro.
 
 Section linking_table.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (* Demo with incr_macro for the setup *)

--- a/theories/exercises/cerise_tutorial.v
+++ b/theories/exercises/cerise_tutorial.v
@@ -26,7 +26,7 @@ Section base_program.
       are the registers and the memory. Moreover, we need the machine parameters
       in the context, which abstract the encoding and the decoding function
       (for instance, to encode the instructions). *)
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (** The program is a list of instructions. As the machine has a Von Neumann

--- a/theories/exercises/cerise_tutorial_solutions.v
+++ b/theories/exercises/cerise_tutorial_solutions.v
@@ -10,7 +10,7 @@ From cap_machine.proofmode Require Import proofmode tactics_helpers contiguous.
 Open Scope Z_scope.
 
 Section base_program.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   Definition prog_instrs : list Word :=

--- a/theories/exercises/increment.v
+++ b/theories/exercises/increment.v
@@ -23,7 +23,7 @@ Tactic Notation "iHide" constr(irisH) "as" ident(coqH) :=
 Section program_call.
   From cap_machine Require Import call callback.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
   Context {nainv: logrel_na_invs Σ}.
 

--- a/theories/exercises/restrict_buffer.v
+++ b/theories/exercises/restrict_buffer.v
@@ -10,7 +10,7 @@ Open Scope Z_scope.
 (** Variant of the `subseg_buffer` where we don't restrict the range
     of the buffer, but we restrict the permission *)
 Section program_ro.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           `{MP: MachineParameters}.
   Context {nainv: logrel_na_invs Σ}.
 
@@ -249,7 +249,7 @@ End program_ro.
 
 Section program_closure_ro.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           `{MP: MachineParameters}.
   Context {nainv: logrel_na_invs Σ}.
   Definition closure_roN : namespace := nroot .@ "closure_ro".

--- a/theories/exercises/subseg_buffer.v
+++ b/theories/exercises/subseg_buffer.v
@@ -11,7 +11,7 @@ Open Scope Z_scope.
 (** Exercise - the region is already allocated and the capability pointing to this
     region is in R1. As a first step, the adversary code is known and just halts. *)
 Section base_program.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   (** `r_mem` is the register that contains the capability pointing to
@@ -164,7 +164,7 @@ End base_program.
     resources. *)
 Section base_program_CPS.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg : sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg : sealStoreG Σ}
           `{MP: MachineParameters}.
 
   (* For a clearer context, we will use these following notations *)

--- a/theories/exercises/subseg_buffer_call.v
+++ b/theories/exercises/subseg_buffer_call.v
@@ -27,7 +27,7 @@ Open Scope Z_scope.
 
 Section program_call.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg : sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg : sealStoreG Σ}
           `{MP: MachineParameters}.
   Context {nainv: logrel_na_invs Σ}.
 
@@ -1035,7 +1035,7 @@ Next Obligation.
 Qed.
 
 Section prog_call_correct.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg : sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg : sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{memlayout: memory_layout}.
 

--- a/theories/exercises/subseg_buffer_closure.v
+++ b/theories/exercises/subseg_buffer_closure.v
@@ -15,7 +15,7 @@ Open Scope Z_scope.
  *)
 Section closure_program.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           `{MP: MachineParameters}.
   Context {nainv: logrel_na_invs Σ}.
   Definition Nclosure : namespace := nroot .@ "closure".

--- a/theories/exercises/subseg_buffer_malloc.v
+++ b/theories/exercises/subseg_buffer_malloc.v
@@ -11,7 +11,7 @@ Open Scope Z_scope.
 (** Secondly, the other approach is to dynamically allocate the region with
     the `malloc` macro. *)
 Section malloc_program.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg : sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg : sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MP: MachineParameters}.
 

--- a/theories/ftlr/AddSubLt.v
+++ b/theories/ftlr/AddSubLt.v
@@ -7,7 +7,7 @@ From cap_machine Require Import machine_base.
 From cap_machine.rules Require Import rules_base.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Get.v
+++ b/theories/ftlr/Get.v
@@ -7,7 +7,7 @@ From cap_machine.rules Require Export rules_Get rules_base.
 From cap_machine Require Import stdpp_extra.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/IsUnique.v
+++ b/theories/ftlr/IsUnique.v
@@ -16,7 +16,7 @@ Section fundamental.
   Implicit Types lw : (leibnizO LWord).
   Implicit Types interp : (D).
 
-  (* TODO @Bastien redo the proof in the same style as Load or Store *)
+  (* TODO @June redo the proof in the same style as Load or Store *)
   Lemma isunique_case (lregs : leibnizO LReg)
     (p : Perm) (b e a : Addr) (v : Version)
     (lw : LWord) (dst src : RegName) (P : D):

--- a/theories/ftlr/IsUnique.v
+++ b/theories/ftlr/IsUnique.v
@@ -7,7 +7,7 @@ From cap_machine.rules Require Import rules_IsUnique.
 Import uPred.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Jmp.v
+++ b/theories/ftlr/Jmp.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base.
 From cap_machine.rules Require Import rules_Jmp.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Jnz.v
+++ b/theories/ftlr/Jnz.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base.
 From cap_machine.rules Require Import rules_base rules_Jnz.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Lea.v
+++ b/theories/ftlr/Lea.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base interp_weakening.
 From cap_machine.rules Require Import rules_base rules_Lea.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Load.v
+++ b/theories/ftlr/Load.v
@@ -7,7 +7,7 @@ From cap_machine.rules Require Import rules_Load.
 Import uPred.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Mov.v
+++ b/theories/ftlr/Mov.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base.
 From cap_machine.rules Require Import rules_base rules_Mov.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Restrict.v
+++ b/theories/ftlr/Restrict.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base interp_weakening.
 From cap_machine.rules Require Import rules_base rules_Restrict.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Seal.v
+++ b/theories/ftlr/Seal.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base interp_weakening.
 From cap_machine.rules Require Import rules_base rules_Seal.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Store.v
+++ b/theories/ftlr/Store.v
@@ -8,7 +8,7 @@ Import uPred.
 
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/Subseg.v
+++ b/theories/ftlr/Subseg.v
@@ -7,7 +7,7 @@ From cap_machine Require Import addr_reg region.
 From cap_machine.rules Require Import rules_base rules_Subseg.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/UnSeal.v
+++ b/theories/ftlr/UnSeal.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base interp_weakening.
 From cap_machine.rules Require Import rules_base rules_UnSeal.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/ftlr_base.v
+++ b/theories/ftlr/ftlr_base.v
@@ -4,7 +4,7 @@ From stdpp Require Import base.
 From cap_machine Require Export logrel.
 
 Section fundamental.
- Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr/interp_weakening.v
+++ b/theories/ftlr/interp_weakening.v
@@ -6,7 +6,7 @@ From cap_machine.ftlr Require Import ftlr_base.
 From cap_machine Require Import addr_reg region.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/AddSubLt_binary.v
+++ b/theories/ftlr_binary/AddSubLt_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_AddSubLt.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/GetWType_binary.v
+++ b/theories/ftlr_binary/GetWType_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_GetWType.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Get_binary.v
+++ b/theories/ftlr_binary/Get_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Get.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Jmp_binary.v
+++ b/theories/ftlr_binary/Jmp_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Jmp.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Jnz_binary.v
+++ b/theories/ftlr_binary/Jnz_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Jnz.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Lea_binary.v
+++ b/theories/ftlr_binary/Lea_binary.v
@@ -7,7 +7,7 @@ From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Lea.
 From cap_machine.ftlr_binary Require Import interp_weakening.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Load_binary.v
+++ b/theories/ftlr_binary/Load_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Load.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Mov_binary.v
+++ b/theories/ftlr_binary/Mov_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Mov.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Restrict_binary.v
+++ b/theories/ftlr_binary/Restrict_binary.v
@@ -7,7 +7,7 @@ From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Rest
 From cap_machine.ftlr_binary Require Import interp_weakening.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Seal_binary.v
+++ b/theories/ftlr_binary/Seal_binary.v
@@ -8,7 +8,7 @@ From cap_machine.ftlr_binary Require Import interp_weakening.
 From cap_machine.rules_binary Require Import rules_binary_base.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Store_binary.v
+++ b/theories/ftlr_binary/Store_binary.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary.
 From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Store.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/Subseg_binary.v
+++ b/theories/ftlr_binary/Subseg_binary.v
@@ -7,7 +7,7 @@ From cap_machine.rules_binary Require Import rules_binary_base rules_binary_Subs
 From cap_machine.ftlr_binary Require Import interp_weakening.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/UnSeal_binary.v
+++ b/theories/ftlr_binary/UnSeal_binary.v
@@ -8,7 +8,7 @@ From cap_machine.ftlr_binary Require Import interp_weakening.
 From cap_machine.rules_binary Require Import rules_binary_base.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/ftlr_base_binary.v
+++ b/theories/ftlr_binary/ftlr_base_binary.v
@@ -4,7 +4,7 @@ From stdpp Require Import base.
 From cap_machine Require Export logrel_binary.
 
 Section fundamental.
- Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+ Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/ftlr_binary/interp_weakening.v
+++ b/theories/ftlr_binary/interp_weakening.v
@@ -6,7 +6,7 @@ From cap_machine Require Import ftlr_base_binary region.
 From cap_machine Require Import addr_reg.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/fundamental.v
+++ b/theories/fundamental.v
@@ -7,9 +7,9 @@ From cap_machine Require Export logrel.
 From cap_machine.rules Require Import rules_EInit rules_EDeInit rules_EStoreId rules_IsUnique. (* temporarily *)
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
-          `{MP: MachineParameters}.
+          `{MachineParameters}.
 
   Notation D := ((leibnizO LWord) -n> iPropO Σ).
   Notation R := ((leibnizO LReg) -n> iPropO Σ).
@@ -54,7 +54,7 @@ Section fundamental.
       assert ((b <= a)%a ∧ (a < e)%a) as Hbae.
       { eapply in_range_is_correctLPC; eauto. solve_addr. }
       assert (p = RX ∨ p = RWX) as Hp.
-      { inversion i. inversion H1; cbn in *; simplify_eq. auto. }
+      { inversion i. inversion H2; cbn in *; simplify_eq. auto. }
       iDestruct (read_allowed_inv_regs with "[] Hinv") as (P) "(#Hinva & #Hread)";[eauto|destruct Hp as [-> | ->];auto|iFrame "% #"|].
       rewrite /interp_ref_inv /=.
       iInv (logN.@(a, v)) as (lw) "[>Ha HP]" "Hcls".
@@ -138,13 +138,14 @@ Section fundamental.
         iIntros (Hcontr); inversion Hcontr.
 
       + (* TODO @Denis EStoreId *)
-        iApply (wp_estoreid with "[HPC Ha]"); eauto. iFrame.
-        iNext. iIntros "[HPC Ha] /=".
-        iApply wp_pure_step_later; auto.
-        iMod ("Hcls" with "[HP Ha]");[iExists lw;iFrame|iModIntro].
-        iNext ; iIntros "_".
-        iApply wp_value.
-        iIntros (Hcontr); inversion Hcontr.
+        admit.
+        (* iApply (wp_estoreid with "[HPC Ha]"); eauto. iFrame. *)
+        (* iNext. iIntros "[HPC Ha] /=". *)
+        (* iApply wp_pure_step_later; auto. *)
+        (* iMod ("Hcls" with "[HP Ha]");[iExists lw;iFrame|iModIntro]. *)
+        (* iNext ; iIntros "_". *)
+        (* iApply wp_value. *)
+        (* iIntros (Hcontr); inversion Hcontr. *)
 
       + iApply (isunique_case with "[] [] [] [] [] [Hown] [Ha] [HP] [Hcls] [HPC] [Hmap]");
           try iAssumption; eauto.

--- a/theories/fundamental.v
+++ b/theories/fundamental.v
@@ -276,7 +276,7 @@ Section fundamental.
     iFrame.
   Qed.
 
-  (* TODO @Bastien Which formulation ?
+  (* TODO @June Which formulation ?
      1) ([∗ list] la;lw ∈ (fun a => (a,v)) <$> (finz.seq_between b e);l, la ↦ₐ lw)
      2) ([∗ list] a;lw ∈ finz.seq_between b e;l, (a,v) ↦ₐ lw)
      3) Both

--- a/theories/fundamental_binary.v
+++ b/theories/fundamental_binary.v
@@ -5,7 +5,7 @@ From cap_machine.ftlr_binary Require Export Mov_binary Load_binary AddSubLt_bina
 From cap_machine Require Export logrel_binary.
 
 Section bin_log_def.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MP: MachineParameters}.
   Notation D := ((prodO (leibnizO Word) (leibnizO Word)) -n> iProp Σ).
@@ -15,7 +15,7 @@ Section bin_log_def.
 End bin_log_def.
 
 Section fundamental.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MP: MachineParameters}.
 

--- a/theories/logical_mapsto.v
+++ b/theories/logical_mapsto.v
@@ -854,7 +854,7 @@ Lemma state_corresponds_unique_in_registers
   (src : RegName) (lwsrc : LWord):
   state_phys_log_corresponds phr phm lr lm vmap ->
   lr !! src = Some lwsrc ->
-  unique_in_registers phr src (lword_get_word lwsrc) ->
+  unique_in_registers phr (lword_get_word lwsrc) (Some src) ->
   unique_in_registersL lr src lwsrc.
 Proof.
   move=> [Hreg_inv Hmem_inv] Hlr_src Hunique.
@@ -873,7 +873,7 @@ Lemma state_corresponds_unique_in_memory
   (src : RegName) (lwsrc : LWord):
   state_phys_log_corresponds phr phm lr lm vmap ->
   lr !! src = Some lwsrc ->
-  unique_in_memory phm (lword_get_word lwsrc) ->
+  unique_in_memory phm (lword_get_word lwsrc) None ->
   unique_in_memoryL lm vmap lwsrc.
 Proof.
   move=> [Hreg_inv Hmem_inv] Hlr_src Hunique.
@@ -893,13 +893,13 @@ Lemma sweep_true_specL
   (src : RegName) (lwsrc : LWord):
   state_phys_log_corresponds phr phm lr lm vmap →
   lr !! src = Some lwsrc →
-  sweep phm phr src = true →
+  sweep_reg phm phr src = true →
   unique_in_machineL lr lm vmap src lwsrc.
 Proof.
   intros HLinv Hlr_src Hsweep.
   assert (Hphr_src : phr !! src = Some (lword_get_word lwsrc))
     by (by eapply state_corresponds_reg_get_word).
-  apply sweep_spec with (wsrc := (lword_get_word lwsrc)) in Hsweep ; auto.
+  apply sweep_reg_spec with (wsrc := (lword_get_word lwsrc)) in Hsweep ; auto.
   specialize (Hsweep Hphr_src).
   destruct Hsweep as [Hunique_reg Hunique_mem].
   intros _.

--- a/theories/logical_mapsto.v
+++ b/theories/logical_mapsto.v
@@ -2356,9 +2356,9 @@ Class ceriseG Σ := CeriseG {
   (* Heap for registers *)
   reg_gen_regG :: gen_heapGS RegName LWord Σ;
   (* The ghost resource of all enclaves that have ever existed *)
-  enclaves_hist :: inG Σ (authR (gmapR TIndex (agreeR EId)));
+  enclaves_hist :: inG Σ (authR (gmapR TIndex (agreeR EIdentity)));
   (* The ghost resource of current, known alive enclaves *)
-  enclaves_live :: inG Σ (authR (gmapR TIndex (exclR EId)));
+  enclaves_live :: inG Σ (authR (gmapR TIndex (exclR EIdentity)));
   (* ghost names for the resources *)
   enclaves_name_prev : gname;
   enclaves_name_cur : gname;
@@ -2367,32 +2367,32 @@ Class ceriseG Σ := CeriseG {
 
  (* Assertions over enclaves *)
 
-Definition enclaves_cur (tbl : gmap TIndex EId) `{ceriseG Σ} :=
+Definition enclaves_cur (tbl : gmap TIndex EIdentity) `{ceriseG Σ} :=
   own (inG0 := enclaves_live) enclaves_name_cur (● (Excl <$> tbl)).
 
-Definition enclaves_prev (tbl : gmap TIndex EId) `{ceriseG Σ} :=
+Definition enclaves_prev (tbl : gmap TIndex EIdentity) `{ceriseG Σ} :=
   own (inG0 := enclaves_hist) enclaves_name_prev (● (to_agree <$> tbl)).
 
-Definition enclaves_all (tbl : gmap TIndex EId) `{ceriseG Σ} :=
+Definition enclaves_all (tbl : gmap TIndex EIdentity) `{ceriseG Σ} :=
   own (inG0 := enclaves_hist) enclaves_name_all (● (to_agree <$> tbl)).
 
 (* Fragmental resources *)
 
-Definition enclave_cur (eid : TIndex) (identity : EId) `{ceriseG Σ} :=
+Definition enclave_cur (eid : TIndex) (identity : EIdentity) `{ceriseG Σ} :=
   own (inG0 := enclaves_live) enclaves_name_cur (auth_frag {[eid := Excl identity]}).
 
 Definition enclave_prev (eid : TIndex) `{ceriseG Σ} : iProp Σ :=
   ∃ id ,
   own (inG0 := enclaves_hist) enclaves_name_prev (auth_frag {[eid := to_agree id]}).
 
-Definition enclave_all (eid : TIndex) (id : EId) `{ceriseG Σ} : iProp Σ :=
+Definition enclave_all (eid : TIndex) (id : EIdentity) `{ceriseG Σ} : iProp Σ :=
   own (inG0 := enclaves_hist) enclaves_name_all (auth_frag {[eid := to_agree id]}).
 
 (* Notations for fragmental resources *)
 (* @TODO: denis *)
 
 Definition state_interp_logical (σ : cap_lang.state) `{!ceriseG Σ} : iProp Σ :=
-  ∃ lr lm vmap (cur_tb prev_tb all_tb : gmap TIndex EId) ,
+  ∃ lr lm vmap (cur_tb prev_tb all_tb : gmap TIndex EIdentity) ,
     gen_heap_interp lr ∗
     gen_heap_interp lm ∗
     ⌜cur_tb = σ.(etable)⌝ ∗

--- a/theories/logical_mapsto.v
+++ b/theories/logical_mapsto.v
@@ -2357,6 +2357,7 @@ Class regG Σ := RegG {
   reg_invG : invGS Σ;
   reg_gen_regG :: gen_heapGS RegName LWord Σ; }.
 
+(* TODO: @Denis, add enclave/etable resources *)
 Definition state_interp_logical (σ : cap_lang.state) `{!memG Σ, !regG Σ} : iProp Σ :=
   ∃ lr lm vmap , gen_heap_interp lr ∗ gen_heap_interp lm ∗
                       ⌜state_phys_log_corresponds σ.(reg) σ.(mem) lr lm vmap⌝.

--- a/theories/logical_mapsto.v
+++ b/theories/logical_mapsto.v
@@ -2396,21 +2396,11 @@ Definition enclave_all (eid : TIndex) (id : EId) `{enclaveG Σ} : iProp Σ :=
 (* Notations for fragmental resources *)
 (* @TODO: denis *)
 
-
-Axiom σ : cap_lang.state.
-Check snd <$> σ.(etable).
-
-Print TIndex. (* @TODO: should be nat *)
-
-Print seq.
-
-Print ENum. (* @TODO: should also be a nat *)
-
 Definition state_interp_logical (σ : cap_lang.state) `{!memG Σ, !regG Σ, !enclaveG Σ} : iProp Σ :=
   ∃ lr lm vmap cur_tb prev_tb all_tb ,
     gen_heap_interp lr ∗
     gen_heap_interp lm ∗
-    ⌜cur_tb = snd <$> σ.(etable)⌝ ∗
+    ⌜cur_tb = σ.(etable)⌝ ∗
     enclaves_cur cur_tb ∗
     enclaves_prev prev_tb ∗
     enclaves_all all_tb ∗
@@ -2421,7 +2411,7 @@ Definition state_interp_logical (σ : cap_lang.state) `{!memG Σ, !regG Σ, !enc
     ⌜state_phys_log_corresponds σ.(reg) σ.(mem) lr lm vmap⌝.
 
 (* invariants for memory, and a state interpretation for (mem,reg) *)
-Global Instance memG_irisG `{MachineParameters} `{!memG Σ, !regG Σ} : irisGS cap_lang Σ := {
+Global Instance memG_irisG `{MachineParameters} `{!memG Σ, !regG Σ, !enclaveG Σ} : irisGS cap_lang Σ := {
   iris_invGS := mem_invG;
   state_interp σ _ κs _ := state_interp_logical σ;
   fork_post _ := True%I;

--- a/theories/logrel.v
+++ b/theories/logrel.v
@@ -776,7 +776,7 @@ Section logrel.
   Definition compute_mask_range (E : coPset) (b e : Addr) (v : Version) : coPset :=
     (compute_mask E (logical_range_set b e v)).
 
-  (* TODO @Bastien is there a way to generalize the opening of the list of invariant ? *)
+  (* TODO @June is there a way to generalize the opening of the list of invariant ? *)
   (* Lemma for opening invariants of a region *)
   Lemma open_region_inv
     (E : coPset)

--- a/theories/logrel.v
+++ b/theories/logrel.v
@@ -31,7 +31,7 @@ Class logrel_na_invs Σ :=
 
 (** interp : is a unary logical relation. *)
 Section logrel.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ} {sealsg: sealStoreG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ} {sealsg: sealStoreG Σ}
           {nainv: logrel_na_invs Σ}
           `{MachineParameters}.
 

--- a/theories/logrel_binary.v
+++ b/theories/logrel_binary.v
@@ -25,7 +25,7 @@ Ltac solve_proper ::= (repeat intros ?; simpl; auto_equiv_binary).
 
 (** interpb : is a binary logical relation. *)
 Section logrel.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           {nainv: logrel_na_invs Σ} {cfgsg: cfgSG Σ}
           `{MachineParameters}.
 

--- a/theories/machine_base.v
+++ b/theories/machine_base.v
@@ -57,9 +57,9 @@ Inductive instr: Type :=
 | GetOType (dst r: RegName)
 | Seal (dst r1 r2: RegName)
 | UnSeal (dst r1 r2: RegName)
-| EInit (dst r: RegName)
-| EDeInit (dst r: RegName)
-| EStoreId (dst r1 r2: RegName)
+| EInit (dst src: RegName)
+| EDeInit (r: RegName)
+| EStoreId (dst src: RegName)
 | IsUnique (dst src: RegName)
 | Fail
 | Halt.
@@ -782,9 +782,9 @@ Proof.
       | GetWType dst r => GenNode 16 [GenLeaf (inl dst); GenLeaf (inl r)]
       | Seal dst r1 r2 => GenNode 17 [GenLeaf (inl dst); GenLeaf (inl r1); GenLeaf (inl r2)]
       | UnSeal dst r1 r2 => GenNode 18 [GenLeaf (inl dst); GenLeaf (inl r1); GenLeaf (inl r2)]
-      | EInit dst r => GenNode 19 [GenLeaf (inl dst); GenLeaf (inl r)]
-      | EDeInit dst r => GenNode 20 [GenLeaf (inl dst); GenLeaf (inl r)]
-      | EStoreId dst r1 r2 => GenNode 21 [GenLeaf (inl dst); GenLeaf (inl r1); GenLeaf (inl r2)]
+      | EInit dst src => GenNode 19 [GenLeaf (inl dst); GenLeaf (inl src)]
+      | EDeInit r => GenNode 20 [GenLeaf (inl r)]
+      | EStoreId dst src => GenNode 21 [GenLeaf (inl dst); GenLeaf (inl src)]
       | IsUnique dst src => GenNode 22 [GenLeaf (inl dst); GenLeaf (inl src)]
       | Fail => GenNode 23 []
       | Halt => GenNode 24 []
@@ -810,9 +810,9 @@ Proof.
       | GenNode 16 [GenLeaf (inl dst); GenLeaf (inl r)] => GetWType dst r
       | GenNode 17 [GenLeaf (inl dst); GenLeaf (inl r1); GenLeaf (inl r2)] => Seal dst r1 r2
       | GenNode 18 [GenLeaf (inl dst); GenLeaf (inl r1); GenLeaf (inl r2)] => UnSeal dst r1 r2
-      | GenNode 19 [GenLeaf (inl dst); GenLeaf (inl r)] => EInit dst r
-      | GenNode 20 [GenLeaf (inl dst); GenLeaf (inl r)] => EDeInit dst r
-      | GenNode 21 [GenLeaf (inl dst); GenLeaf (inl r1); GenLeaf (inl r2)] => EStoreId dst r1 r2
+      | GenNode 19 [GenLeaf (inl dst); GenLeaf (inl src)] => EInit dst src
+      | GenNode 20 [GenLeaf (inl r)] => EDeInit r
+      | GenNode 21 [GenLeaf (inl dst); GenLeaf (inl src)] => EStoreId dst src
       | GenNode 22 [GenLeaf (inl dst); GenLeaf (inl src)] => IsUnique dst src
       | GenNode 23 [] => Fail
       | GenNode 24 [] => Halt

--- a/theories/machine_base.v
+++ b/theories/machine_base.v
@@ -81,8 +81,10 @@ Definition Mem := gmap Addr Word.
 Definition MaxENum: nat := 256.
 Global Opaque MaxENum.
 (* Definition TIndex := (finz TableSize). *)
-Definition TIndex := (finz MaxENum).
+(* Definition TIndex := (finz MaxENum). *)
+Definition TIndex := Z.
 Definition EId := Z. (* For now, we assume the hash to be unbounded *)
+(* Definition ENum := (finz MaxENum). *)
 Definition ENum := Z. (* The max # of supported enclaves *)
 Definition ETable := gmap TIndex (EId * ENum). (* Check sail impl. of CHERi-TrEE for how to get table index ? They don't have a table but a distinct memory region *)
 

--- a/theories/machine_base.v
+++ b/theories/machine_base.v
@@ -25,14 +25,14 @@ Definition permit_unseal (s : SealPerms) :=
   s.2.
 
 Inductive Sealable: Type :=
-| SCap: Perm -> Addr -> Addr -> Addr -> Sealable
-| SSealRange: SealPerms -> OType -> OType -> OType -> Sealable.
+| SCap       (p : Perm) (b e a : Addr)
+| SSealRange (sp : SealPerms) (ob oe oa : OType).
 
 (* Having different syntactic categories here simplifies the definition of instructions later, but requires some duplication in defining bounds changes and lea on sealing ranges *)
 Inductive Word: Type :=
 | WInt (z : Z)
 | WSealable (sb : Sealable)
-| WSealed: OType → Sealable → Word.
+| WSealed (ot : OType) (sb : Sealable).
 
 Notation WCap p b e a := (WSealable (SCap p b e a)).
 Notation WSealRange p b e a := (WSealable (SSealRange p b e a)).
@@ -76,14 +76,14 @@ Definition Reg := gmap RegName Word.
 Definition Mem := gmap Addr Word.
 
 (* State involved in supporting enclaves *)
-Definition TableSize: nat := 128.
-Global Opaque TableSize.
-Definition MaxENum: nat := 1024.
+(* Definition TableSize: nat := 128. *)
+(* Global Opaque TableSize. *)
+Definition MaxENum: nat := 256.
 Global Opaque MaxENum.
 (* Definition TIndex := (finz TableSize). *)
 Definition TIndex := (finz MaxENum).
 Definition EId := Z. (* For now, we assume the hash to be unbounded *)
-Definition ENum := (finz MaxENum). (* The max # of supported enclaves *)
+Definition ENum := Z. (* The max # of supported enclaves *)
 Definition ETable := gmap TIndex (EId * ENum). (* Check sail impl. of CHERi-TrEE for how to get table index ? They don't have a table but a distinct memory region *)
 
 (* EqDecision instances *)
@@ -752,7 +752,7 @@ Qed.
 Global Instance word_inhabited: Inhabited Word := populate (WInt 0).
 Global Instance addr_inhabited: Inhabited Addr := populate (@finz.FinZ MemNum 0%Z eq_refl eq_refl).
 Global Instance otype_inhabited: Inhabited OType := populate (@finz.FinZ ONum 0%Z eq_refl eq_refl).
-Global Instance enum_inhabited: Inhabited ENum := populate (@finz.FinZ MaxENum 0%Z eq_refl eq_refl).
+(* Global Instance enum_inhabited: Inhabited ENum := populate (@finz.FinZ MaxENum 0%Z eq_refl eq_refl). *)
 (* Global Instance tindex_inhabited: Inhabited TIndex := populate (@finz.FinZ TableSize 0%Z eq_refl eq_refl). *)
 Global Instance etable_inhabited: Inhabited ETable. Proof. solve [typeclasses eauto]. Defined.
 

--- a/theories/machine_base.v
+++ b/theories/machine_base.v
@@ -76,17 +76,10 @@ Definition Reg := gmap RegName Word.
 Definition Mem := gmap Addr Word.
 
 (* State involved in supporting enclaves *)
-(* Definition TableSize: nat := 128. *)
-(* Global Opaque TableSize. *)
-Definition MaxENum: nat := 256.
-Global Opaque MaxENum.
-(* Definition TIndex := (finz TableSize). *)
-(* Definition TIndex := (finz MaxENum). *)
-Definition TIndex := Z.
+Definition TIndex := nat.
 Definition EId := Z. (* For now, we assume the hash to be unbounded *)
-(* Definition ENum := (finz MaxENum). *)
-Definition ENum := Z. (* The max # of supported enclaves *)
-Definition ETable := gmap TIndex (EId * ENum). (* Check sail impl. of CHERi-TrEE for how to get table index ? They don't have a table but a distinct memory region *)
+Definition ENum := nat. (* The max # of supported enclaves *)
+Definition ETable := gmap TIndex EId. (* Check sail impl. of CHERi-TrEE for how to get table index ? They don't have a table but a distinct memory region *)
 
 (* EqDecision instances *)
 

--- a/theories/machine_base.v
+++ b/theories/machine_base.v
@@ -77,9 +77,9 @@ Definition Mem := gmap Addr Word.
 
 (* State involved in supporting enclaves *)
 Definition TIndex := nat.
-Definition EId := Z. (* For now, we assume the hash to be unbounded *)
+Definition EIdentity := Z. (* For now, we assume the hash to be unbounded *)
 Definition ENum := nat. (* The max # of supported enclaves *)
-Definition ETable := gmap TIndex EId. (* Check sail impl. of CHERi-TrEE for how to get table index ? They don't have a table but a distinct memory region *)
+Definition ETable := gmap TIndex EIdentity. (* Check sail impl. of CHERi-TrEE for how to get table index ? They don't have a table but a distinct memory region *)
 
 (* EqDecision instances *)
 

--- a/theories/machine_base.v
+++ b/theories/machine_base.v
@@ -70,7 +70,6 @@ Definition cst : Z → (Z+RegName)%type := inl.
 Coercion regn : RegName >-> sum.
 Coercion cst : Z >-> sum.
 
-
 (* Registers and memory: maps from register names/addresses to words *)
 
 Definition Reg := gmap RegName Word.
@@ -81,10 +80,11 @@ Definition TableSize: nat := 128.
 Global Opaque TableSize.
 Definition MaxENum: nat := 1024.
 Global Opaque MaxENum.
-Definition TIndex := (finz TableSize).
+(* Definition TIndex := (finz TableSize). *)
+Definition TIndex := (finz MaxENum).
 Definition EId := Z. (* For now, we assume the hash to be unbounded *)
 Definition ENum := (finz MaxENum). (* The max # of supported enclaves *)
-Definition ETable := gmap TIndex (EId * ENum).
+Definition ETable := gmap TIndex (EId * ENum). (* Check sail impl. of CHERi-TrEE for how to get table index ? They don't have a table but a distinct memory region *)
 
 (* EqDecision instances *)
 
@@ -753,7 +753,7 @@ Global Instance word_inhabited: Inhabited Word := populate (WInt 0).
 Global Instance addr_inhabited: Inhabited Addr := populate (@finz.FinZ MemNum 0%Z eq_refl eq_refl).
 Global Instance otype_inhabited: Inhabited OType := populate (@finz.FinZ ONum 0%Z eq_refl eq_refl).
 Global Instance enum_inhabited: Inhabited ENum := populate (@finz.FinZ MaxENum 0%Z eq_refl eq_refl).
-Global Instance tindex_inhabited: Inhabited TIndex := populate (@finz.FinZ TableSize 0%Z eq_refl eq_refl).
+(* Global Instance tindex_inhabited: Inhabited TIndex := populate (@finz.FinZ TableSize 0%Z eq_refl eq_refl). *)
 Global Instance etable_inhabited: Inhabited ETable. Proof. solve [typeclasses eauto]. Defined.
 
 Global Instance instr_countable : Countable instr.

--- a/theories/machine_parameters.v
+++ b/theories/machine_parameters.v
@@ -36,6 +36,9 @@ Class MachineParameters := {
             end;
     decode_encode_word_type_inv :
     forall w, decodeWordType (encodeWordType w) = w;
+    hash {A : Type} : A ->  Z;
+    hash_concat : Z -> Z -> Z;
+    (* TODO: injectivity and other axioms about hash *)
   }.
 
 (* Lift the encoding / decoding between Z and instructions on Words: simplify

--- a/theories/proofmode/contiguous.v
+++ b/theories/proofmode/contiguous.v
@@ -245,7 +245,7 @@ Section Contiguous.
       { cbn in *. eauto. } }
   Qed.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}.
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}.
 
   (* Note that we are assuming that both prog1 and prog2 are nonempty *)
   Lemma contiguous_between_program_split prog1 prog2 (φ : Addr → Word → iProp Σ) a i j :

--- a/theories/proofmode/contiguous.v
+++ b/theories/proofmode/contiguous.v
@@ -360,7 +360,7 @@ Section ContiguousL.
     - split; intros; inversion H ; simplify_eq; econstructor; eauto; by apply IHl.
   Qed.
 
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}.
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}.
   Lemma contiguous_betweenL_program_split
     (prog1 prog2 : list LWord) (φ : LAddr → LWord → iProp Σ)
     (a : list Addr) (i j : Addr) (v : Version) :

--- a/theories/proofmode/mkregion_helpers.v
+++ b/theories/proofmode/mkregion_helpers.v
@@ -159,7 +159,7 @@ Proof.
     iFrame. iApply (IHl with "H"). solve_addr. }
 Qed.
 
-Lemma mkregion_prepare `{memG Σ} (a e: Addr) l :
+Lemma mkregion_prepare `{ceriseG Σ} (a e: Addr) l :
   (a + length l)%a = Some e →
   ⊢ ([∗ map] k↦v ∈ mkregion a e l, k ↦ₐ v) ==∗ ([∗ list] k;v ∈ (finz.seq_between a e); l, k ↦ₐ v).
 Proof.

--- a/theories/proofmode/proofmode.v
+++ b/theories/proofmode/proofmode.v
@@ -14,7 +14,7 @@ From Ltac2 Require Option Bool Constr.
 Set Default Proof Mode "Classic".
 
 Section codefrag.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
     `{MP: MachineParameters}.
 
 Lemma codefrag_lookup_acc a v (cs: list LWord) (i: nat) w:
@@ -146,7 +146,7 @@ Proof. unfold NthSubBlock. intros -> ->. rewrite app_assoc //. Qed.
 #[export] Hint Resolve NthSubBlock_S : proofmode_focus.
 
 Section codefrag_subblock.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
   Lemma codefrag_block0_acc a0 v (l1 l2: list LWord):
@@ -354,17 +354,17 @@ Instance FramableCodefrag_default a v l :
   FramableCodefrag a v l
 | 100. Qed.
 
-Instance FramableMachineResource_reg `{regG Σ} r lw :
+Instance FramableMachineResource_reg `{ceriseG Σ} r lw :
   FramableRegisterPointsto r lw →
   FramableMachineResource (r ↦ᵣ lw).
 Qed.
 
-Instance FramableMachineResource_mem `{memG Σ} a v dq w :
+Instance FramableMachineResource_mem `{ceriseG Σ} a v dq w :
   FramableMemoryPointsto a v dq w →
   FramableMachineResource ((a,v) ↦ₐ{dq} w).
 Qed.
 
-Instance FramableMachineResource_codefrag `{memG Σ} a v l :
+Instance FramableMachineResource_codefrag `{ceriseG Σ} a v l :
   FramableCodefrag a v l →
   FramableMachineResource (codefrag a v l).
 Qed.

--- a/theories/proofmode/proofmode_instr_rules.v
+++ b/theories/proofmode/proofmode_instr_rules.v
@@ -126,6 +126,6 @@ Ltac dispatch_instr_rule instr cont :=
   | Halt => cont (@wp_halt)
   (* not found *)
   (* TODO @Denis EInit, EDeInit, EStoreId *)
-  (* TODO @Bastien IsUnique *)
+  (* TODO @June IsUnique *)
   | _ => fail "No suitable rule found for instruction" instr
   end.

--- a/theories/proofmode/region.v
+++ b/theories/proofmode/region.v
@@ -8,7 +8,7 @@ From machine_utils Require Import finz_interval.
 From cap_machine Require Import addr_reg. (* Required because of a weird Coq bug related to imports *)
 
 Section region.
-  Context `{MachineParameters, memG Σ, regG Σ, cfg: cfgSG Σ}.
+  Context `{MachineParameters, ceriseG Σ, cfg: cfgSG Σ}.
 
   Lemma isWithin_finz_seq_between_decomposition {z} (a0 a1 b e : finz z):
     (b <= a0 /\ a1 <= e /\ a0 <= a1)%f ->
@@ -72,9 +72,9 @@ Section region.
       + auto.
       + iDestruct "HA2" as "[HA2 HA3]".
         iDestruct "HB2" as "[HB2 HB3]".
-        generalize (drop_S' _ _ _ _ _ H3). intros Hdws.
-        rewrite <- H3. rewrite HWS. rewrite Hdws.
-        iExists w. iFrame. by rewrite <- H3.
+        generalize (drop_S' _ _ _ _ _ H2). intros Hdws.
+        rewrite <- H2. rewrite HWS. rewrite Hdws.
+        iExists w. iFrame. by rewrite <- H2.
     - iIntros "A". iDestruct "A" as (w Hws) "[A1 [B1 [A2 [B2 AB]]]]".
       unfold region_mapsto. rewrite (finz_seq_between_decomposition b a e) // map_app.
       iDestruct "AB" as "[A3 B3]".
@@ -374,7 +374,7 @@ Global Notation "a ∈ₐ [[ b , e ]]" := (in_range a b e)
 
 
 Section codefrag.
-  Context {Σ:gFunctors} {memg:memG Σ} {regg:regG Σ}
+  Context {Σ:gFunctors} {ceriseg:ceriseG Σ}
           `{MP: MachineParameters}.
 
 Definition codefrag (a: Addr) (v : Version) (cs: list LWord) :=

--- a/theories/rules/rules_AddSubLt.v
+++ b/theories/rules/rules_AddSubLt.v
@@ -6,8 +6,8 @@ From cap_machine Require Import machine_base.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_EDeInit.v
+++ b/theories/rules/rules_EDeInit.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_EDeInit.v
+++ b/theories/rules/rules_EDeInit.v
@@ -27,27 +27,28 @@ Section cap_lang_rules.
       Instr Executable @ E
     {{{ RET FailedV; PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v ∗ (pc_a, pc_v) ↦ₐ lw }}}.
   Proof.
-    iIntros (Hinstr Hvpc φ) "[Hpc Hpca] Hφ".
-    apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc.
-    iApply wp_lift_atomic_head_step_no_fork; auto.
-    iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl.
-    iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv.
-    iDestruct (@gen_heap_valid with "Hr Hpc") as %?.
-    iDestruct (@gen_heap_valid with "Hm Hpca") as %?.
-    iModIntro.
-    iSplitR. by iPureIntro; apply normal_always_head_reducible.
-    iIntros (e2 σ2 efs Hstep).
-    apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)).
-    iNext; iIntros "_".
-    iSplitR; auto. eapply step_exec_inv in Hstep; eauto.
-    2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v)))
-    ; eapply state_corresponds_reg_get_word ; eauto.
-    2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto.
-    cbn in Hstep; simplify_eq.
-    iModIntro.
-    iSplitR "Hφ Hpc Hpca"; last (iApply "Hφ" ; iFrame).
-    iExists lr, lm, vmap.
-    iFrame; auto.
-   Qed.
+   (*  iIntros (Hinstr Hvpc φ) "[Hpc Hpca] Hφ". *)
+   (*  apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc. *)
+   (*  iApply wp_lift_atomic_head_step_no_fork; auto. *)
+   (*  iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl. *)
+   (*  iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv. *)
+   (*  iDestruct (@gen_heap_valid with "Hr Hpc") as %?. *)
+   (*  iDestruct (@gen_heap_valid with "Hm Hpca") as %?. *)
+   (*  iModIntro. *)
+   (*  iSplitR. by iPureIntro; apply normal_always_head_reducible. *)
+   (*  iIntros (e2 σ2 efs Hstep). *)
+   (*  apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)). *)
+   (*  iNext; iIntros "_". *)
+   (*  iSplitR; auto. eapply step_exec_inv in Hstep; eauto. *)
+   (*  2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v))) *)
+   (*  ; eapply state_corresponds_reg_get_word ; eauto. *)
+   (*  2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto. *)
+   (*  cbn in Hstep; simplify_eq. *)
+   (*  iModIntro. *)
+   (*  iSplitR "Hφ Hpc Hpca"; last (iApply "Hφ" ; iFrame). *)
+   (*  iExists lr, lm, vmap. *)
+   (*  iFrame; auto. *)
+   (* Qed. *)
+  Admitted.
 
 End cap_lang_rules.

--- a/theories/rules/rules_EDeInit.v
+++ b/theories/rules/rules_EDeInit.v
@@ -19,8 +19,8 @@ Section cap_lang_rules.
   Implicit Types lmem : LMem.
 
   (* TODO @Denis *)
-  Lemma wp_edeinit E pc_p pc_b pc_e pc_a pc_v lw r1 r2 :
-    decodeInstrWL lw = EDeInit r1 r2 →
+  Lemma wp_edeinit E pc_p pc_b pc_e pc_a pc_v lw src :
+    decodeInstrWL lw = EDeInit src →
     isCorrectLPC (LCap pc_p pc_b pc_e pc_a pc_v) →
 
     {{{ PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v ∗ (pc_a, pc_v) ↦ₐ lw }}}

--- a/theories/rules/rules_EInit.v
+++ b/theories/rules/rules_EInit.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_EInit.v
+++ b/theories/rules/rules_EInit.v
@@ -27,27 +27,28 @@ Section cap_lang_rules.
       Instr Executable @ E
     {{{ RET FailedV; PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v ∗ (pc_a, pc_v) ↦ₐ lw }}}.
   Proof.
-    iIntros (Hinstr Hvpc φ) "[Hpc Hpca] Hφ".
-    apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc.
-    iApply wp_lift_atomic_head_step_no_fork; auto.
-    iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl.
-    iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv.
-    iDestruct (@gen_heap_valid with "Hr Hpc") as %?.
-    iDestruct (@gen_heap_valid with "Hm Hpca") as %?.
-    iModIntro.
-    iSplitR. by iPureIntro; apply normal_always_head_reducible.
-    iIntros (e2 σ2 efs Hstep).
-    apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)).
-    iNext; iIntros "_".
-    iSplitR; auto. eapply step_exec_inv in Hstep; eauto.
-    2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v)))
-    ; eapply state_corresponds_reg_get_word ; eauto.
-    2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto.
-    cbn in Hstep; simplify_eq.
-    iModIntro.
-    iSplitR "Hφ Hpc Hpca"; last (iApply "Hφ" ; iFrame).
-    iExists lr, lm, vmap.
-    iFrame; auto.
-   Qed.
+   (*  iIntros (Hinstr Hvpc φ) "[Hpc Hpca] Hφ". *)
+   (*  apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc. *)
+   (*  iApply wp_lift_atomic_head_step_no_fork; auto. *)
+   (*  iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl. *)
+   (*  iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv. *)
+   (*  iDestruct (@gen_heap_valid with "Hr Hpc") as %?. *)
+   (*  iDestruct (@gen_heap_valid with "Hm Hpca") as %?. *)
+   (*  iModIntro. *)
+   (*  iSplitR. by iPureIntro; apply normal_always_head_reducible. *)
+   (*  iIntros (e2 σ2 efs Hstep). *)
+   (*  apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)). *)
+   (*  iNext; iIntros "_". *)
+   (*  iSplitR; auto. eapply step_exec_inv in Hstep; eauto. *)
+   (*  2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v))) *)
+   (*  ; eapply state_corresponds_reg_get_word ; eauto. *)
+   (*  2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto. *)
+   (*  cbn in Hstep; simplify_eq. *)
+   (*  iModIntro. *)
+   (*  iSplitR "Hφ Hpc Hpca"; last (iApply "Hφ" ; iFrame). *)
+   (*  iExists lr, lm, vmap. *)
+   (*  iFrame; auto. *)
+   (* Qed. *)
+  Admitted.
 
 End cap_lang_rules.

--- a/theories/rules/rules_EStoreId.v
+++ b/theories/rules/rules_EStoreId.v
@@ -5,7 +5,7 @@ From iris.algebra Require Import frac gmap.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
+  Context `{memG Σ, regG Σ, enclavesG Σ}.
   Context `{MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
@@ -25,20 +25,6 @@ Section cap_lang_rules.
     EStoreId_spec FailedV.
 
   Axiom has_lseal : LWord -> ENum -> Prop.
-
-  Print dfrac.
-
-  Print excl.excl.
-
-  Context `{!inG Σ (gmapR nat (agreeR EId))} {mygname : gname}.
-
-  Search gmapR.
-
-  Print gmapR.
-
-  Eval compute in cmra_car (gmapR nat (agreeR EId)).
-  Definition enclave_q (e : ENum) (id : EId) : iProp Σ :=
-    own (A := gmapR nat (agreeR EId)) mygname (empty : gmap nat _).
 
   (* TODO @Denis *)
   Lemma wp_estoreid E pc_p pc_b pc_e pc_a pc_v lw rs1 rs2 rd seal p b e a v any x :
@@ -62,7 +48,7 @@ Section cap_lang_rules.
           ∗ rd ↦ᵣ (LWInt 1)
           ∗ ∃ (id : EId), ∃ (enum : ENum),
             (a, v) ↦ₐ (LWInt id)
-            ∗ (enclave_q enum id)
+            ∗ (enclave_all enum id)
             ∗ ⌜ has_lseal seal enum ⌝
         ) ∨ (
           ⌜ retv = FailedV ⌝

--- a/theories/rules/rules_EStoreId.v
+++ b/theories/rules/rules_EStoreId.v
@@ -1,7 +1,7 @@
 From iris.base_logic Require Export invariants gen_heap.
 From iris.program_logic Require Export weakestpre ectx_lifting.
 From iris.proofmode Require Import proofmode.
-From iris.algebra Require Import frac.
+From iris.algebra Require Import frac gmap.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
@@ -18,34 +18,79 @@ Section cap_lang_rules.
   Implicit Types mem : Mem.
   Implicit Types lmem : LMem.
 
-  (* TODO @Denis *)
-  Lemma wp_estoreid E pc_p pc_b pc_e pc_a pc_v lw dst src :
-    decodeInstrWL lw = EStoreId dst src →
-    isCorrectLPC (LCap pc_p pc_b pc_e pc_a pc_v) →
+  Inductive EStoreId_spec : cap_lang.val -> Prop :=
+  | EStoreId_spec_success:
+    EStoreId_spec NextIV
+  |EStoreId_spec_failure:
+    EStoreId_spec FailedV.
 
-    {{{ PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v ∗ (pc_a, pc_v) ↦ₐ lw }}}
+  Axiom has_lseal : LWord -> ENum -> Prop.
+
+  Print dfrac.
+
+  Print excl.excl.
+
+  Context `{!inG Σ (gmapR nat (agreeR EId))} {mygname : gname}.
+
+  Search gmapR.
+
+  Print gmapR.
+
+  Eval compute in cmra_car (gmapR nat (agreeR EId)).
+  Definition enclave_q (e : ENum) (id : EId) : iProp Σ :=
+    own (A := gmapR nat (agreeR EId)) mygname (empty : gmap nat _).
+
+  (* TODO @Denis *)
+  Lemma wp_estoreid E pc_p pc_b pc_e pc_a pc_v lw rs1 rs2 rd seal p b e a v any x :
+    decodeInstrWL lw = EStoreId rs1 rs2 rd →
+    isCorrectLPC (LCap pc_p pc_b pc_e pc_a pc_v) →
+    writeAllowed p →
+    {{{ PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v
+        ∗ (pc_a, pc_v) ↦ₐ lw
+        ∗ rs1 ↦ᵣ seal
+        ∗ rs2 ↦ᵣ LCap p b e a v
+        ∗ rd ↦ᵣ any
+        ∗ (a, v) ↦ₐ x }}}
       Instr Executable @ E
-    {{{ RET FailedV; PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v ∗ (pc_a, pc_v) ↦ₐ lw }}}.
+    {{{ retv, RET retv;
+        (pc_a, pc_v) ↦ₐ lw
+        (* something with the pc increment *)
+        ∗ rs1 ↦ᵣ seal
+        ∗ rs2 ↦ᵣ LCap p b e a v
+        ∗ (
+          ⌜ retv = NextIV ⌝
+          ∗ rd ↦ᵣ (LWInt 1)
+          ∗ ∃ (id : EId), ∃ (enum : ENum),
+            (a, v) ↦ₐ (LWInt id)
+            ∗ (enclave_q enum id)
+            ∗ ⌜ has_lseal seal enum ⌝
+        ) ∨ (
+          ⌜ retv = FailedV ⌝
+          ∗ rd ↦ᵣ any
+          ∗ (a, v) ↦ₐ x
+        )
+
+    }}}.
   Proof.
-   (*  iIntros (Hinstr Hvpc φ) "[Hpc Hpca] Hφ". *)
-   (*  apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc. *)
-   (*  iApply wp_lift_atomic_head_step_no_fork; auto. *)
-   (*  iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl. *)
-   (*  iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv. *)
-   (*  iDestruct (@gen_heap_valid with "Hr Hpc") as %?. *)
-   (*  iDestruct (@gen_heap_valid with "Hm Hpca") as %?. *)
-   (*  iModIntro. *)
-   (*  iSplitR. by iPureIntro; apply normal_always_head_reducible. *)
-   (*  iIntros (e2 σ2 efs Hstep). *)
-   (*  apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)). *)
-   (*  iNext; iIntros "_". *)
-   (*  iSplitR; auto. eapply step_exec_inv in Hstep; eauto. *)
-   (*  2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v))) *)
-   (*  ; eapply state_corresponds_reg_get_word ; eauto. *)
-   (*  2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto. *)
-   (*  cbn in Hstep; simplify_eq. *)
-   (*  iModIntro. *)
-   (*  iSplitR "Hφ Hpc Hpca"; last (iApply "Hφ" ; iFrame). *)
+    iIntros (Hinstr Hvpc Hwa φ) "(Hpc & Hpca & Hrs1 & Hrs2 & Hrd & Ha) Hφ".
+    apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc.
+    iApply wp_lift_atomic_head_step_no_fork; auto.
+    iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl.
+    iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv.
+    iDestruct (@gen_heap_valid with "Hr Hpc") as %?.
+    iDestruct (@gen_heap_valid with "Hm Hpca") as %?.
+    iModIntro.
+    iSplitR. by iPureIntro; apply normal_always_head_reducible.
+    iIntros (e2 σ2 efs Hstep).
+    apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)).
+    iNext; iIntros "_".
+    iSplitR; auto. eapply step_exec_inv in Hstep; eauto.
+    2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v)))
+    ; eapply state_corresponds_reg_get_word ; eauto.
+    2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto.
+    cbn in Hstep; simplify_eq.
+    iModIntro.
+    (* iSplitR "Hφ Hpc Hpca". last (iApply "Hφ" ; iFrame). *)
    (*  iExists lr, lm, vmap. *)
    (*  iFrame; auto. *)
    (* Qed. *)

--- a/theories/rules/rules_EStoreId.v
+++ b/theories/rules/rules_EStoreId.v
@@ -42,7 +42,7 @@ Section cap_lang_rules.
         ∗ rs ↦ᵣ LWInt otype
         ∗ (
           ⌜ retv = NextIV ⌝
-          ∗ ∃ (id : EId), ∃ (enum : ENum),
+          ∗ ∃ (id : EIdentity), ∃ (enum : ENum),
               rd ↦ᵣ (LWInt id)
               ∗ (enclave_all enum id)
             ∗ ⌜ has_lseal otype enum ⌝

--- a/theories/rules/rules_EStoreId.v
+++ b/theories/rules/rules_EStoreId.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac gmap.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ, enclavesG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.
@@ -24,58 +24,53 @@ Section cap_lang_rules.
   |EStoreId_spec_failure:
     EStoreId_spec FailedV.
 
-  Axiom has_lseal : LWord -> ENum -> Prop.
+  Axiom has_lseal : Z -> ENum -> Prop.
 
   (* TODO @Denis *)
-  Lemma wp_estoreid E pc_p pc_b pc_e pc_a pc_v lw rs1 rs2 rd seal p b e a v any x :
-    decodeInstrWL lw = EStoreId rs1 rs2 rd →
+  Lemma wp_estoreid E pc_p pc_b pc_e pc_a pc_v lw rd rs otype any :
+    decodeInstrWL lw = EStoreId rd rs →
     isCorrectLPC (LCap pc_p pc_b pc_e pc_a pc_v) →
-    writeAllowed p →
     {{{ PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v
         ∗ (pc_a, pc_v) ↦ₐ lw
-        ∗ rs1 ↦ᵣ seal
-        ∗ rs2 ↦ᵣ LCap p b e a v
+        ∗ rs ↦ᵣ LWInt otype
         ∗ rd ↦ᵣ any
-        ∗ (a, v) ↦ₐ x }}}
+    }}}
       Instr Executable @ E
     {{{ retv, RET retv;
         (pc_a, pc_v) ↦ₐ lw
         (* something with the pc increment *)
-        ∗ rs1 ↦ᵣ seal
-        ∗ rs2 ↦ᵣ LCap p b e a v
+        ∗ rs ↦ᵣ LWInt otype
         ∗ (
           ⌜ retv = NextIV ⌝
-          ∗ rd ↦ᵣ (LWInt 1)
           ∗ ∃ (id : EId), ∃ (enum : ENum),
-            (a, v) ↦ₐ (LWInt id)
-            ∗ (enclave_all enum id)
-            ∗ ⌜ has_lseal seal enum ⌝
+              rd ↦ᵣ (LWInt id)
+              ∗ (enclave_all enum id)
+            ∗ ⌜ has_lseal otype enum ⌝
         ) ∨ (
           ⌜ retv = FailedV ⌝
           ∗ rd ↦ᵣ any
-          ∗ (a, v) ↦ₐ x
         )
 
     }}}.
   Proof.
-    iIntros (Hinstr Hvpc Hwa φ) "(Hpc & Hpca & Hrs1 & Hrs2 & Hrd & Ha) Hφ".
+    iIntros (Hinstr Hvpc φ) "(Hpc & Hpca & Hrs & Hrd) Hφ".
     apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc.
     iApply wp_lift_atomic_head_step_no_fork; auto.
     iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl.
-    iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv.
-    iDestruct (@gen_heap_valid with "Hr Hpc") as %?.
-    iDestruct (@gen_heap_valid with "Hm Hpca") as %?.
-    iModIntro.
-    iSplitR. by iPureIntro; apply normal_always_head_reducible.
-    iIntros (e2 σ2 efs Hstep).
-    apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)).
-    iNext; iIntros "_".
-    iSplitR; auto. eapply step_exec_inv in Hstep; eauto.
-    2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v)))
-    ; eapply state_corresponds_reg_get_word ; eauto.
-    2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto.
-    cbn in Hstep; simplify_eq.
-    iModIntro.
+    (* iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv. *)
+    (* iDestruct (@gen_heap_valid with "Hr Hpc") as %?. *)
+    (* iDestruct (@gen_heap_valid with "Hm Hpca") as %?. *)
+    (* iModIntro. *)
+    (* iSplitR. by iPureIntro; apply normal_always_head_reducible. *)
+    (* iIntros (e2 σ2 efs Hstep). *)
+    (* apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)). *)
+    (* iNext; iIntros "_". *)
+    (* iSplitR; auto. eapply step_exec_inv in Hstep; eauto. *)
+    (* 2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v))) *)
+    (* ; eapply state_corresponds_reg_get_word ; eauto. *)
+    (* 2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto. *)
+    (* cbn in Hstep; simplify_eq. *)
+    (* iModIntro. *)
     (* iSplitR "Hφ Hpc Hpca". last (iApply "Hφ" ; iFrame). *)
    (*  iExists lr, lm, vmap. *)
    (*  iFrame; auto. *)

--- a/theories/rules/rules_EStoreId.v
+++ b/theories/rules/rules_EStoreId.v
@@ -19,8 +19,8 @@ Section cap_lang_rules.
   Implicit Types lmem : LMem.
 
   (* TODO @Denis *)
-  Lemma wp_estoreid E pc_p pc_b pc_e pc_a pc_v lw r1 r2 r3 :
-    decodeInstrWL lw = EStoreId r1 r2 r3 →
+  Lemma wp_estoreid E pc_p pc_b pc_e pc_a pc_v lw dst src :
+    decodeInstrWL lw = EStoreId dst src →
     isCorrectLPC (LCap pc_p pc_b pc_e pc_a pc_v) →
 
     {{{ PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v ∗ (pc_a, pc_v) ↦ₐ lw }}}

--- a/theories/rules/rules_EStoreId.v
+++ b/theories/rules/rules_EStoreId.v
@@ -27,27 +27,28 @@ Section cap_lang_rules.
       Instr Executable @ E
     {{{ RET FailedV; PC ↦ᵣ LCap pc_p pc_b pc_e pc_a pc_v ∗ (pc_a, pc_v) ↦ₐ lw }}}.
   Proof.
-    iIntros (Hinstr Hvpc φ) "[Hpc Hpca] Hφ".
-    apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc.
-    iApply wp_lift_atomic_head_step_no_fork; auto.
-    iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl.
-    iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv.
-    iDestruct (@gen_heap_valid with "Hr Hpc") as %?.
-    iDestruct (@gen_heap_valid with "Hm Hpca") as %?.
-    iModIntro.
-    iSplitR. by iPureIntro; apply normal_always_head_reducible.
-    iIntros (e2 σ2 efs Hstep).
-    apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)).
-    iNext; iIntros "_".
-    iSplitR; auto. eapply step_exec_inv in Hstep; eauto.
-    2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v)))
-    ; eapply state_corresponds_reg_get_word ; eauto.
-    2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto.
-    cbn in Hstep; simplify_eq.
-    iModIntro.
-    iSplitR "Hφ Hpc Hpca"; last (iApply "Hφ" ; iFrame).
-    iExists lr, lm, vmap.
-    iFrame; auto.
-   Qed.
+   (*  iIntros (Hinstr Hvpc φ) "[Hpc Hpca] Hφ". *)
+   (*  apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc. *)
+   (*  iApply wp_lift_atomic_head_step_no_fork; auto. *)
+   (*  iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl. *)
+   (*  iDestruct "Hσ1" as (lr lm vmap) "(Hr & Hm & %HLinv)"; simpl in HLinv. *)
+   (*  iDestruct (@gen_heap_valid with "Hr Hpc") as %?. *)
+   (*  iDestruct (@gen_heap_valid with "Hm Hpca") as %?. *)
+   (*  iModIntro. *)
+   (*  iSplitR. by iPureIntro; apply normal_always_head_reducible. *)
+   (*  iIntros (e2 σ2 efs Hstep). *)
+   (*  apply prim_step_exec_inv in Hstep as (-> & -> & (c & -> & Hstep)). *)
+   (*  iNext; iIntros "_". *)
+   (*  iSplitR; auto. eapply step_exec_inv in Hstep; eauto. *)
+   (*  2: rewrite -/((lword_get_word (LCap pc_p pc_b pc_e pc_a pc_v))) *)
+   (*  ; eapply state_corresponds_reg_get_word ; eauto. *)
+   (*  2: eapply state_corresponds_mem_correct_PC ; eauto; cbn ; eauto. *)
+   (*  cbn in Hstep; simplify_eq. *)
+   (*  iModIntro. *)
+   (*  iSplitR "Hφ Hpc Hpca"; last (iApply "Hφ" ; iFrame). *)
+   (*  iExists lr, lm, vmap. *)
+   (*  iFrame; auto. *)
+   (* Qed. *)
+  Admitted.
 
 End cap_lang_rules.

--- a/theories/rules/rules_Get.v
+++ b/theories/rules/rules_Get.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base stdpp_extra.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_IsUnique.v
+++ b/theories/rules/rules_IsUnique.v
@@ -19,7 +19,7 @@ Section cap_lang_rules.
   Implicit Types mem : Mem.
   Implicit Types lmem : LMem.
 
-  (* TODO @Bastien: keep the lemma around,
+  (* TODO @June: keep the lemma around,
      until doing the proof in a `wp_opt2` style
    *)
   Lemma incrementLPC_incrementPC_some regs regs' :

--- a/theories/rules/rules_IsUnique.v
+++ b/theories/rules/rules_IsUnique.v
@@ -284,27 +284,27 @@ Section cap_lang_rules.
     }
     destruct (get_is_lcap_inv lsrcv Hlsrcv) as (p & b & e & a & v & Hget_lsrcv).
 
-    set (lregs' := (<[ dst := LInt (if (sweep mem reg src) then 1 else 0) ]>
-                      (if (andb (sweep mem reg src) (negb (is_sealed lsrcv)) )
+    set (lregs' := (<[ dst := LInt (if (sweep_reg mem reg src) then 1 else 0) ]>
+                      (if (andb (sweep_reg mem reg src) (negb (is_sealed lsrcv)) )
                        then (<[ src := next_version_lword lsrcv]> lregs)
                        else lregs))).
-    set (lr' := (<[ dst := LInt (if (sweep mem reg src) then 1 else 0) ]>
-                   (if (andb (sweep mem reg src) (negb (is_sealed lsrcv)) )
+    set (lr' := (<[ dst := LInt (if (sweep_reg mem reg src) then 1 else 0) ]>
+                   (if (andb (sweep_reg mem reg src) (negb (is_sealed lsrcv)) )
                     then (<[ src := next_version_lword lsrcv]> lr)
                     else lr))).
     assert (lreg_strip lregs' ⊆ lreg_strip lr') as Hlregs'_in_lr'.
     { subst lregs' lr'.
       apply map_fmap_mono, insert_mono.
-      destruct (sweep mem reg src); destruct (is_sealed lsrcv); cbn; auto.
+      destruct (sweep_reg mem reg src); destruct (is_sealed lsrcv); cbn; auto.
       apply insert_mono; auto.
     }
 
     assert ( (lreg_strip lr') =
-               (<[ dst := WInt (if (sweep mem reg src) then 1 else 0) ]> reg))
+               (<[ dst := WInt (if (sweep_reg mem reg src) then 1 else 0) ]> reg))
       as Hstrip_lr'.
     { subst lr'.
       destruct HLinv as [ [Hstrips Hcurreg] _].
-      destruct (sweep mem reg src); destruct (is_sealed lsrcv); cbn; auto.
+      destruct (sweep_reg mem reg src); destruct (is_sealed lsrcv); cbn; auto.
       all: rewrite -Hstrips /lreg_strip !fmap_insert -/(lreg_strip lr) //=.
       rewrite lword_get_word_next_version insert_lcap_lreg_strip; cycle 1 ; eauto.
     }
@@ -324,7 +324,7 @@ Section cap_lang_rules.
         subst lregs' lr'.
         apply fmap_is_Some.
         destruct (decide (dst = PC)); simplify_map_eq ; auto.
-        destruct (sweep mem reg src) ; simplify_map_eq ; auto.
+        destruct (sweep_reg mem reg src) ; simplify_map_eq ; auto.
         destruct (is_sealed lsrcv) ; simplify_map_eq ; auto.
         destruct (decide (src = PC)) ; simplify_map_eq ; auto.
       }
@@ -341,7 +341,7 @@ Section cap_lang_rules.
       iSplitR "Hφ Hmap Hmem"
       ; [ iExists lr, lm, vmap; iFrame; auto
         | iApply "Hφ" ; iFrame].
-      destruct (sweep mem reg src)
+      destruct (sweep_reg mem reg src)
       ; destruct (is_sealed lsrcv)
       ; subst lregs'
       ; cbn in *
@@ -372,7 +372,7 @@ Section cap_lang_rules.
 
     (* Start the different cases now *)
     (* sweep success or sweep fail *)
-    destruct (sweep mem reg src) as [|] eqn:Hsweep; cycle 1.
+    destruct (sweep_reg mem reg src) as [|] eqn:Hsweep; cycle 1.
     { (* sweep is false *)
       iMod ((gen_heap_update_inSepM _ _ dst ) with "Hr Hmap") as "[Hr Hmap]"; eauto.
       iMod ((gen_heap_update_inSepM _ _ PC ) with "Hr Hmap") as "[Hr Hmap]"; eauto

--- a/theories/rules/rules_Jmp.v
+++ b/theories/rules/rules_Jmp.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.
@@ -36,7 +36,12 @@ Section cap_lang_rules.
     apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc.
     iApply wp_lift_atomic_head_step_no_fork; auto.
     iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl.
-    iDestruct "Hσ1" as (lr lm vmap) "(Hr0 & Hm & %HLinv)"; simpl in HLinv.
+    iDestruct "Hσ1" as (lr lm vmap tbl_cur tbl_prev tbl_all)
+        "(Hr0 & Hm
+         & -> & Htbl_cur & Htbl_prev & Htbl_all
+         & %Hdom_tbl1 & %Hdom_tbl2 & %Hdom_tbl3 & %Hdom_tbl4
+         & %HLinv)"
+    ; cbn in HLinv, Hdom_tbl1, Hdom_tbl2, Hdom_tbl3, Hdom_tbl4.
     iDestruct (@gen_heap_valid with "Hm Hpc_a") as %?; auto.
     iDestruct (@gen_heap_valid with "Hr0 HPC") as %?.
     iDestruct (@gen_heap_valid with "Hr0 Hr") as %Hr_r0.
@@ -55,8 +60,10 @@ Section cap_lang_rules.
 
     iMod (@gen_heap_update with "Hr0 HPC") as "[Hr0 HPC]".
     iSplitR "Hφ HPC Hpc_a Hr" ; [|by iApply "Hφ" ; iFrame].
-    iExists _, lm, vmap; iFrame; eauto; cbn.
-    iPureIntro; econstructor; eauto
+    iExists _, lm, vmap,_,_,_; iFrame; eauto; cbn.
+    iPureIntro
+    ; repeat (split ; first done)
+    ; econstructor; eauto
     ; [| by destruct HLinv as [_ ?]]
     ; destruct HLinv as [[Hstrips Hcur_reg] HmemInv]
     ; cbn in *.
@@ -82,7 +89,12 @@ Section cap_lang_rules.
     apply isCorrectLPC_isCorrectPC_iff in Hvpc; cbn in Hvpc.
     iApply wp_lift_atomic_head_step_no_fork; auto.
     iIntros (σ1 ns l1 l2 nt) "Hσ1 /=". destruct σ1; simpl.
-    iDestruct "Hσ1" as (lr lm vmap) "(Hr0 & Hm & %HLinv)"; simpl in HLinv.
+    iDestruct "Hσ1" as (lr lm vmap tbl_cur tbl_prev tbl_all)
+        "(Hr0 & Hm
+         & -> & Htbl_cur & Htbl_prev & Htbl_all
+         & %Hdom_tbl1 & %Hdom_tbl2 & %Hdom_tbl3 & %Hdom_tbl4
+         & %HLinv)"
+    ; cbn in HLinv, Hdom_tbl1, Hdom_tbl2, Hdom_tbl3, Hdom_tbl4.
     iDestruct (@gen_heap_valid with "Hm Hpc_a") as %?; auto.
     iDestruct (@gen_heap_valid with "Hr0 HPC") as %Hr_PC.
     iDestruct (@gen_heap_valid with "Hr0 HPC") as %Hr_PC'.
@@ -100,8 +112,10 @@ Section cap_lang_rules.
 
     iMod (@gen_heap_update with "Hr0 HPC") as "[Hr0 HPC]".
     iSplitR "Hφ HPC Hpc_a" ; [|by iApply "Hφ" ; iFrame].
-    iExists _, lm, vmap; iFrame; eauto; cbn.
-    iPureIntro; econstructor; eauto
+    iExists _, lm, vmap,_,_,_; iFrame; eauto; cbn.
+    iPureIntro
+    ; repeat (split ; first done)
+    ; econstructor; eauto
     ; [| by destruct HLinv as [_ ?]]
     ; destruct HLinv as [[Hstrips Hcur_reg] HmemInv]
     ; cbn in *.

--- a/theories/rules/rules_Jnz.v
+++ b/theories/rules/rules_Jnz.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_Lea.v
+++ b/theories/rules/rules_Lea.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{HM: memG Σ, HR: regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_Load.v
+++ b/theories/rules/rules_Load.v
@@ -340,7 +340,7 @@ Section cap_lang_rules.
     destruct Hspec as [ | * Hfail ].
      { (* Success *)
        (* FIXME: fragile *)
-       destruct H5 as [Hrr2 _]. simplify_map_eq.
+       destruct H2 as [Hrr2 _]. simplify_map_eq.
        iDestruct (memMap_resource_2gen_d_dq with "[Hmem]") as "[Hpc_a Ha]"; cbn in *.
        { iExists lmem,dfracs; iSplitL; eauto.
          iPureIntro. Unshelve. 3: exact (a0, v0). 2: exact (pc_a, pc_v).
@@ -354,7 +354,7 @@ Section cap_lang_rules.
              rewrite andb_true_iff ; split; [solve_addr | by rewrite Nat.eqb_refl].
            }
            rewrite Heq in Hmem, Hdfracs ; simplify_map_eq.
-           rewrite prod_merge_insert prod_merge_empty_l in H6.
+           rewrite prod_merge_insert prod_merge_empty_l in H3.
            by simplify_map_eq.
          - rewrite not_and_r in Heq.
            assert (((a0 =? pc_a)%f && (v0 =? pc_v)) = false) as Hneq.
@@ -365,7 +365,7 @@ Section cap_lang_rules.
            assert ((pc_a,pc_v) ≠ (a0,v0)).
            { intro ; simplify_eq. destruct Heq ; congruence. }
            rewrite Hneq in Hmem, Hdfracs ; simplify_map_eq.
-           rewrite !prod_merge_insert prod_merge_empty_l in H6.
+           rewrite !prod_merge_insert prod_merge_empty_l in H3.
            by simplify_map_eq.
        }
        pose proof (mem_implies_loadv _ _ _ _ _ _ _ _ Hmem Hload) as Hloadv; eauto.
@@ -487,7 +487,7 @@ Section cap_lang_rules.
     destruct Hspec as [ | * Hfail ].
      { (* Success *)
        iApply "Hφ".
-       destruct H3 as [Hrr2 _]. simplify_map_eq.
+       destruct H0 as [Hrr2 _]. simplify_map_eq.
        iDestruct (memMap_resource_2gen_d_dq with "[Hmem]") as "[Hpc_a Ha]"; cbn in *.
        { iExists lmem,dfracs; iSplitL; eauto.
          iPureIntro. Unshelve. 3: exact (a0, v0). 2: exact (pc_a, pc_v).
@@ -501,7 +501,7 @@ Section cap_lang_rules.
              rewrite andb_true_iff ; split; [solve_addr | by rewrite Nat.eqb_refl].
            }
            rewrite Heq in Hmem, Hfracs ; simplify_map_eq.
-           rewrite prod_merge_insert prod_merge_empty_l in H4.
+           rewrite prod_merge_insert prod_merge_empty_l in H1.
            by simplify_map_eq.
          - rewrite not_and_r in Heq.
            assert (((a0 =? pc_a)%f && (v0 =? pc_v)) = false) as Hneq.
@@ -512,7 +512,7 @@ Section cap_lang_rules.
            assert ((pc_a,pc_v) ≠ (a0,v0)).
            { intro ; simplify_eq. destruct Heq ; congruence. }
            rewrite Hneq in Hmem, Hfracs ; simplify_map_eq.
-           rewrite !prod_merge_insert prod_merge_empty_l in H4.
+           rewrite !prod_merge_insert prod_merge_empty_l in H1.
            by simplify_map_eq.
        }
        pose proof (mem_implies_loadv _ _ _ _ _ _ _ _ Hmem Hload) as Hloadv; eauto.
@@ -619,7 +619,7 @@ Section cap_lang_rules.
     destruct Hspec as [ | * Hfail ].
      { (* Success *)
        iApply "Hφ".
-       destruct H4 as [Hrr2 _]. simplify_map_eq.
+       destruct H1 as [Hrr2 _]. simplify_map_eq.
        iDestruct (memMap_resource_2ne with "Hmem") as "[Hpc_a Ha]";auto.
        incrementLPC_inv; simplify_map_eq.
        rewrite insert_insert insert_insert.
@@ -666,7 +666,7 @@ Section cap_lang_rules.
     destruct Hspec as [ | * Hfail ].
      { (* Success *)
        iApply "Hφ".
-       destruct H3 as [Hrr2 _]. simplify_map_eq.
+       destruct H0 as [Hrr2 _]. simplify_map_eq.
        rewrite -memMap_resource_1_dq.
        incrementLPC_inv.
        simplify_map_eq.
@@ -675,7 +675,7 @@ Section cap_lang_rules.
      { (* Failure (contradiction) *)
        destruct Hfail; try incrementLPC_inv; simplify_map_eq; eauto.
        apply isCorrectLPC_ra_wb in Hvpc. apply andb_prop_elim in Hvpc as [Hra Hwb].
-       destruct o; apply Is_true_false in H3. all: try congruence. done.
+       destruct o; apply Is_true_false in H0. all: try congruence. done.
      }
   Qed.
 

--- a/theories/rules/rules_Load.v
+++ b/theories/rules/rules_Load.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base stdpp_extra.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_Mov.v
+++ b/theories/rules/rules_Mov.v
@@ -7,8 +7,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_Restrict.v
+++ b/theories/rules/rules_Restrict.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_Seal.v
+++ b/theories/rules/rules_Seal.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_Store.v
+++ b/theories/rules/rules_Store.v
@@ -282,7 +282,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H3 as [Hrr2 _]. simplify_map_eq.
+       destruct H0 as [Hrr2 _]. simplify_map_eq.
        rewrite memMap_resource_1.
        incrementLPC_inv.
        simplify_map_eq.
@@ -292,7 +292,7 @@ Section cap_lang_rules.
        apply isCorrectLPC_ra_wb in Hvpc.
        apply andb_prop_elim in Hvpc as [_ Hwb].
        destruct X; try incrementLPC_inv; simplify_map_eq; eauto.
-       destruct o; last apply Is_true_false in H2. all:try congruence.
+       destruct o; last apply Is_true_false in H. all:try congruence.
        done.
      }
   Qed.
@@ -327,7 +327,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H4 as [Hrr2 _]. simplify_map_eq.
+       destruct H1 as [Hrr2 _]. simplify_map_eq.
        rewrite memMap_resource_1.
        incrementLPC_inv.
        simplify_map_eq.
@@ -336,7 +336,7 @@ Section cap_lang_rules.
      { (* Failure (contradiction) *)
        destruct X; try incrementLPC_inv; simplify_map_eq; eauto.
        apply isCorrectLPC_ra_wb in Hvpc. apply andb_prop_elim in Hvpc as [_ Hwb].
-       destruct o; last apply Is_true_false in H3. congruence. done. congruence.
+       destruct o; last apply Is_true_false in H0. congruence. done. congruence.
      }
     Qed.
 
@@ -367,7 +367,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H3 as [Hrr2 _]. simplify_map_eq.
+       destruct H0 as [Hrr2 _]. simplify_map_eq.
        rewrite memMap_resource_1.
        incrementLPC_inv.
        simplify_map_eq.
@@ -376,7 +376,7 @@ Section cap_lang_rules.
       { (* Failure (contradiction) *)
        destruct X; try incrementLPC_inv; simplify_map_eq; eauto.
        apply isCorrectLPC_ra_wb in Hvpc. apply andb_prop_elim in Hvpc as [_ Hwb].
-       destruct o; last apply Is_true_false in H2. congruence. done. congruence.
+       destruct o; last apply Is_true_false in H. congruence. done. congruence.
      }
     Qed.
 
@@ -411,7 +411,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H4 as [Hrr2 _]. simplify_map_eq.
+       destruct H1 as [Hrr2 _]. simplify_map_eq.
        rewrite memMap_resource_1.
        incrementLPC_inv.
        simplify_map_eq.
@@ -464,7 +464,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H5 as [Hrr2 _]. simplify_map_eq.
+       destruct H2 as [Hrr2 _]. simplify_map_eq.
        destruct ((a0 =? pc_a)%Z && (v0 =? pc_v)) eqn:Heq; subst mem.
        - rewrite andb_true_iff in Heq.
          destruct Heq as [Heq_a Heq_v].
@@ -484,7 +484,7 @@ Section cap_lang_rules.
          rewrite insert_commute; last congruence. rewrite insert_insert.
          iDestruct (memMap_resource_2ne with "Hmem") as "[Ha0 Hpc_a]" ; first congruence.
          incrementLPC_inv.
-         rewrite lookup_insert_ne in H6; last congruence. simplify_map_eq. rewrite insert_insert.
+         rewrite lookup_insert_ne in H3; last congruence. simplify_map_eq. rewrite insert_insert.
          iDestruct (regs_of_map_2 with "[$Hmap]") as "[HPC Hsrc]"; eauto. iFrame.
      }
      { (* Failure (contradiction) *)
@@ -577,7 +577,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H4 as [Hrr2 _]. simplify_map_eq.
+       destruct H1 as [Hrr2 _]. simplify_map_eq.
        rewrite memMap_resource_1.
        incrementLPC_inv.
        simplify_map_eq.
@@ -622,7 +622,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H6 as [Hrr2 _]. simplify_map_eq.
+       destruct H3 as [Hrr2 _]. simplify_map_eq.
        rewrite memMap_resource_1.
        incrementLPC_inv.
        simplify_map_eq.
@@ -664,7 +664,7 @@ Section cap_lang_rules.
     { eapply mem_neq_implies_allow_store_map with (a := a) (v := v)
                                                   (pc_a := pc_a) (pc_v := pc_v)
       ; eauto.
-      rewrite pair_eq in H5. apply not_and_l in H5. destruct H5 ; [left|right]; done.
+      rewrite pair_eq in H2. apply not_and_l in H2. destruct H2 ; [left|right]; done.
       by simplify_map_eq. }
     iNext. iIntros (regs' mem' retv) "(#Hspec & Hmem & Hmap)".
     iDestruct "Hspec" as %Hspec.
@@ -672,7 +672,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H7 as [Hrr2 _]. simplify_map_eq.
+       destruct H4 as [Hrr2 _]. simplify_map_eq.
        rewrite insert_commute // insert_insert.
        iDestruct (memMap_resource_2ne with "Hmem") as "[Hpc_a Ha]";auto.
        incrementLPC_inv.
@@ -713,7 +713,7 @@ Section cap_lang_rules.
     { eapply mem_neq_implies_allow_store_map with (a := a) (v := v)
                                                   (pc_a := pc_a) (pc_v := pc_v)
       ; eauto.
-      rewrite pair_eq in H3. apply not_and_l in H3. destruct H3 ; [left|right]; done.
+      rewrite pair_eq in H0. apply not_and_l in H0. destruct H0 ; [left|right]; done.
       by simplify_map_eq. }
     iNext. iIntros (regs' mem' retv) "(#Hspec & Hmem & Hmap)".
     iDestruct "Hspec" as %Hspec.
@@ -721,7 +721,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H5 as [Hrr2 _]. simplify_map_eq.
+       destruct H2 as [Hrr2 _]. simplify_map_eq.
        rewrite insert_commute // insert_insert.
        iDestruct (memMap_resource_2ne with "Hmem") as "[Hpc_a Ha]";auto.
        incrementLPC_inv.
@@ -762,7 +762,7 @@ Section cap_lang_rules.
     { eapply mem_neq_implies_allow_store_map with (a := a) (v := v)
                                                   (pc_a := pc_a) (pc_v := pc_v)
       ; eauto.
-      rewrite pair_eq in H3. apply not_and_l in H3. destruct H3 ; [left|right]; done.
+      rewrite pair_eq in H0. apply not_and_l in H0. destruct H0 ; [left|right]; done.
       by simplify_map_eq. }
     iNext. iIntros (regs' mem' retv) "(#Hspec & Hmem & Hmap)".
     iDestruct "Hspec" as %Hspec.
@@ -770,7 +770,7 @@ Section cap_lang_rules.
     destruct Hspec.
      { (* Success *)
        iApply "Hφ".
-       destruct H5 as [Hrr2 _]. simplify_map_eq.
+       destruct H2 as [Hrr2 _]. simplify_map_eq.
        rewrite insert_commute // insert_insert.
        iDestruct (memMap_resource_2ne with "Hmem") as "[Hpc_a Ha]";auto.
        incrementLPC_inv.

--- a/theories/rules/rules_Store.v
+++ b/theories/rules/rules_Store.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base stdpp_extra.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_Subseg.v
+++ b/theories/rules/rules_Subseg.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_UnSeal.v
+++ b/theories/rules/rules_UnSeal.v
@@ -5,8 +5,8 @@ From iris.algebra Require Import frac.
 From cap_machine Require Export rules_base.
 
 Section cap_lang_rules.
-  Context `{memG Σ, regG Σ}.
-  Context `{MachineParameters}.
+  Context `{ceriseg: ceriseG Σ}.
+  Context `{MP: MachineParameters}.
   Implicit Types P Q : iProp Σ.
   Implicit Types σ : ExecConf.
   Implicit Types c : cap_lang.expr.

--- a/theories/rules/rules_base.v
+++ b/theories/rules/rules_base.v
@@ -1076,7 +1076,7 @@ Proof.
   rewrite (lookup_weaken _ _ _ _ HrpPC Hincl) in Hi.
   destruct w; try easy.
   destruct sb; try easy.
-  now destruct (f1 + 1)%a.
+  now destruct (a + 1)%a.
 Qed.
 
 (* todo: instead, define updatePC on top of incrementPC *)
@@ -1158,7 +1158,7 @@ Proof.
   unfold update_reg, update_regs.
   destruct w; try now cbn.
   destruct sb; try now cbn.
-  destruct (f1 + 1)%a; try now cbn.
+  destruct (a + 1)%a; try now cbn.
 Qed.
 
 (*--- incrementLPC ---*)


### PR DESCRIPTION
Adds operational semantics for 
- EInit
- EDeInit
- EStoreId
- IsUnique

Renames some types for clarity, e.g. `EId` is disambiguated to `EIdentity`.
Simplifies some existing assumptions w.r.t. bounded number of OTypes.
Adds new CMRA for tracking the enclave table
Merges existing CMRAs for memory and registers together with the above into a `ceriseG` CMRA

Still missing:
notations for fragmental view on the `all`, `cur` and `prev` tables
WP rules for `EInit` and `EDeInit` (soon...)